### PR TITLE
Tb plot exp fiff fix

### DIFF
--- a/eelbrain/load/fiff.py
+++ b/eelbrain/load/fiff.py
@@ -623,8 +623,10 @@ def mne_Epochs(ds, i_start='i_start', raw=None,
     kwargs['name'] = name = name.format(name=ds.name)
     if 'tstart' in kwargs:
         kwargs['tmin'] = kwargs['tstart']
+        del kwargs['tstart']
     if 'tstop' in kwargs:
         kwargs['tmax'] = kwargs['tstop']
+        del kwargs['tstop']
 
     events = mne_events(ds=ds, i_start=i_start)
     # epochs with (event_id == None) does not use columns 1 and 2 of events

--- a/eelbrain/load/fiff.py
+++ b/eelbrain/load/fiff.py
@@ -622,11 +622,9 @@ def mne_Epochs(ds, i_start='i_start', raw=None,
 
     kwargs['name'] = name = name.format(name=ds.name)
     if 'tstart' in kwargs:
-        kwargs['tmin'] = kwargs['tstart']
-        del kwargs['tstart']
+        kwargs['tmin'] = kwargs.pop('tstart')
     if 'tstop' in kwargs:
-        kwargs['tmax'] = kwargs['tstop']
-        del kwargs['tstop']
+        kwargs['tmax'] = kwargs.pop('tstop')
 
     events = mne_events(ds=ds, i_start=i_start)
     # epochs with (event_id == None) does not use columns 1 and 2 of events

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -490,7 +490,7 @@ def _plt_uts(ax, layer, color=None, xdim='time', kwargs={}):
 
 class _ax_clusters:
     def __init__(self, ax, layers, color=None, pmax=0.05, ptrend=0.1,
-                 t = t, xdim='time', title=None):
+                 t = {}, xdim='time', title=None):
         Y = layers[0]
 
         if title:

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -485,9 +485,13 @@ class _ax_clusters:
                 title = title.format(name=Y.name)
             ax.set_title(title)
 
-        if tkwargs:
-            t = Y.properties.get('threshold', None)
-            ax.axhline(t, **tkwargs)
+        t = Y.properties.get('threshold', None)
+        if t:
+            if tkwargs:
+                ax.axhline(t, **tkwargs)
+            else:
+                ax.axhline(t)
+
         ylabel = Y.properties.get('unit', None)
 
         _plt_uts(ax, Y, color=color, xdim=xdim)

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -486,8 +486,8 @@ class _ax_clusters:
             ax.set_title(title)
 
         t = Y.properties.get('threshold', None)
-        if t:
-            if tkwargs:
+        if t is not None:
+            if tkwargs is not None:
                 ax.axhline(t, **tkwargs)
             else:
                 ax.axhline(t)

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -339,10 +339,11 @@ def _ax_stat(ax, ct, colors, legend_h={},
 
 
 class clusters(_base.subplot_figure):
-    def __init__(self, epochs, pmax=0.05, ptrend=0.1, t=True, ls = 'solid', 
+    def __init__(self, epochs, pmax=0.05, ptrend=0.1, 
                  title="plot.uts.clusters", figtitle=None, axtitle='{name}',
                  cm=_cm.jet, width=6, height=3, frame=.1, dpi=90,
-                 tcolor = 'k', overlay=False):
+                  overlay=False, t = {}):
+        
         """
         Specialized plotting function for Permutation Cluster test results
 
@@ -350,10 +351,12 @@ class clusters(_base.subplot_figure):
             Maximum p-value of clusters to plot as solid.
         ptrend : scalar
             Maximum p-value of clusters to plot as trend.
-        t : bool
+        t : dict
             Plot threshold for forming clusters.
-        ls : str
-            Line style. e.g. ['solid' | 'dashed' | 'dashdot' | 'dotted']
+            Contains threshold plotting properties.
+        tlinestyle : str
+            Line style for threshold. 
+            e.g. ['solid' | 'dashed' | 'dashdot' | 'dotted']
         tcolor : str
             Line color for threshold.
         title : str
@@ -393,6 +396,12 @@ class clusters(_base.subplot_figure):
         width = .85
         height = .95 / Nax
 
+        t = {'color': 'k'}
+        if color:
+            t['color'] = tcolor
+        if tlinestyle:
+            t['linestyle'] = tlinestyle
+        
         for i, layers in enumerate(epochs):
             if i < Nax:  # create axes
                 ax = self.figure.add_subplot(Nax, 1, i + 1)
@@ -402,9 +411,8 @@ class clusters(_base.subplot_figure):
 
             # color
             color = cm(i / N)
-            cax = _ax_clusters(ax, layers, color=color, pmax=pmax, t=t,
-                               tcolor = tcolor, ls = ls, title=title_, 
-                               ptrend=ptrend)
+            cax = _ax_clusters(ax, layers, color=color, pmax=pmax, 
+                               title=title_, ptrend=ptrend, t = t)
             self._caxes.append(cax)
 
         self._show(figtitle=figtitle)
@@ -482,8 +490,7 @@ def _plt_uts(ax, layer, color=None, xdim='time', kwargs={}):
 
 class _ax_clusters:
     def __init__(self, ax, layers, color=None, pmax=0.05, ptrend=0.1,
-                 t=True, ls = 'solid', tcolor = 'k', xdim='time', 
-                 title=None):
+                 t = t, xdim='time', title=None):
         Y = layers[0]
 
         if title:
@@ -491,10 +498,8 @@ class _ax_clusters:
                 title = title.format(name=Y.name)
             ax.set_title(title)
 
-        if t is True:
-            t = Y.properties.get('threshold', None)
         if t:
-            ax.axhline(t, color = tcolor, ls = ls)
+            ax.axhline(**t)
         ylabel = Y.properties.get('unit', None)
 
         _plt_uts(ax, Y, color=color, xdim=xdim)

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -340,7 +340,7 @@ class clusters(_base.subplot_figure):
     def __init__(self, epochs, pmax=0.05, ptrend=0.1, 
                  title="plot.uts.clusters", figtitle=None, axtitle='{name}',
                  cm=_cm.jet, width=6, height=3, frame=.1, dpi=90,
-                  overlay=False, t = {'linestyle': 'solid', 'tcolor': 'k'}):
+                  overlay=False, t = {'linestyle': 'solid', 'color': 'k'}):
         
         """
         Specialized plotting function for Permutation Cluster test results

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -350,13 +350,8 @@ class clusters(_base.subplot_figure):
         ptrend : scalar
             Maximum p-value of clusters to plot as trend.
         t : dict
+            Contains kwargs for matplotlib axhline for threshold plotting.
             Plot threshold for forming clusters.
-            Contains threshold plotting properties.
-        linestyle : str
-            Line style for threshold. 
-            e.g. ['solid' | 'dashed' | 'dashdot' | 'dotted']
-        color : str
-            Line color for threshold.
         title : str
             Window title.
         figtitle : str | None

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -353,7 +353,7 @@ class clusters(_base.subplot_figure):
         t : bool
             Plot threshold for forming clusters.
         ls : str
-            Line style. e.g. [‘solid’ | ‘dashed’ | ‘dashdot’ | ‘dotted’]
+            Line style. e.g. ['solid' | 'dashed' | 'dashdot' | 'dotted']
         tcolor : str
             Line color for threshold.
         title : str
@@ -482,7 +482,7 @@ def _plt_uts(ax, layer, color=None, xdim='time', kwargs={}):
 
 class _ax_clusters:
     def __init__(self, ax, layers, color=None, pmax=0.05, ptrend=0.1,
-                 t=True, ls = 'solid', tcolor = tcolor, xdim='time', 
+                 t=True, ls = 'solid', tcolor = 'k', xdim='time', 
                  title=None):
         Y = layers[0]
 

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -337,11 +337,11 @@ def _ax_stat(ax, ct, colors, legend_h={},
 
 
 class clusters(_base.subplot_figure):
-    def __init__(self, epochs, pmax=0.05, ptrend=0.1, 
+    def __init__(self, epochs, pmax=0.05, ptrend=0.1,
                  title="plot.uts.clusters", figtitle=None, axtitle='{name}',
                  cm=_cm.jet, width=6, height=3, frame=.1, dpi=90,
                  overlay=False, t={'linestyle': 'solid', 'color': 'k'}):
-        
+
         """
         Specialized plotting function for Permutation Cluster test results
 
@@ -388,7 +388,7 @@ class clusters(_base.subplot_figure):
 
         width = .85
         height = .95 / Nax
-        
+
         for i, layers in enumerate(epochs):
             if i < Nax:  # create axes
                 ax = self.figure.add_subplot(Nax, 1, i + 1)
@@ -398,8 +398,8 @@ class clusters(_base.subplot_figure):
 
             # color
             color = cm(i / N)
-            cax = _ax_clusters(ax, layers, color=color, pmax=pmax, 
-                               title=title_, ptrend=ptrend, tkwargs = t)
+            cax = _ax_clusters(ax, layers, color=color, pmax=pmax,
+                               title=title_, ptrend=ptrend, tkwargs=t)
             self._caxes.append(cax)
 
         self._show(figtitle=figtitle)
@@ -477,7 +477,7 @@ def _plt_uts(ax, layer, color=None, xdim='time', kwargs={}):
 
 class _ax_clusters:
     def __init__(self, ax, layers, color=None, pmax=0.05, ptrend=0.1,
-                 tkwargs = {}, xdim='time', title=None):
+                 tkwargs={}, xdim='time', title=None):
         Y = layers[0]
 
         if title:

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -340,7 +340,7 @@ class clusters(_base.subplot_figure):
     def __init__(self, epochs, pmax=0.05, ptrend=0.1, 
                  title="plot.uts.clusters", figtitle=None, axtitle='{name}',
                  cm=_cm.jet, width=6, height=3, frame=.1, dpi=90,
-                  overlay=False, t = {'linestyle': 'solid', 'color': 'k'}):
+                 overlay=False, t={'linestyle': 'solid', 'color': 'k'}):
         
         """
         Specialized plotting function for Permutation Cluster test results

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -342,7 +342,7 @@ class clusters(_base.subplot_figure):
     def __init__(self, epochs, pmax=0.05, ptrend=0.1, 
                  title="plot.uts.clusters", figtitle=None, axtitle='{name}',
                  cm=_cm.jet, width=6, height=3, frame=.1, dpi=90,
-                  overlay=False, t = {}):
+                  overlay=False, t = {'linestyle': 'solid', 'tcolor': 'k'}):
         
         """
         Specialized plotting function for Permutation Cluster test results
@@ -354,10 +354,10 @@ class clusters(_base.subplot_figure):
         t : dict
             Plot threshold for forming clusters.
             Contains threshold plotting properties.
-        tlinestyle : str
+        linestyle : str
             Line style for threshold. 
             e.g. ['solid' | 'dashed' | 'dashdot' | 'dotted']
-        tcolor : str
+        color : str
             Line color for threshold.
         title : str
             Window title.
@@ -395,12 +395,6 @@ class clusters(_base.subplot_figure):
 
         width = .85
         height = .95 / Nax
-
-        t = {'color': 'k'}
-        if color:
-            t['color'] = tcolor
-        if tlinestyle:
-            t['linestyle'] = tlinestyle
         
         for i, layers in enumerate(epochs):
             if i < Nax:  # create axes
@@ -412,7 +406,7 @@ class clusters(_base.subplot_figure):
             # color
             color = cm(i / N)
             cax = _ax_clusters(ax, layers, color=color, pmax=pmax, 
-                               title=title_, ptrend=ptrend, t = t)
+                               title=title_, ptrend=ptrend, tkwargs = t)
             self._caxes.append(cax)
 
         self._show(figtitle=figtitle)
@@ -490,7 +484,7 @@ def _plt_uts(ax, layer, color=None, xdim='time', kwargs={}):
 
 class _ax_clusters:
     def __init__(self, ax, layers, color=None, pmax=0.05, ptrend=0.1,
-                 t = {}, xdim='time', title=None):
+                 tkwargs = {}, xdim='time', title=None):
         Y = layers[0]
 
         if title:
@@ -498,8 +492,9 @@ class _ax_clusters:
                 title = title.format(name=Y.name)
             ax.set_title(title)
 
-        if t:
-            ax.axhline(**t)
+        if tkwargs:
+            t = Y.properties.get('threshold', None)
+            ax.axhline(t, **tkwargs)
         ylabel = Y.properties.get('unit', None)
 
         _plt_uts(ax, Y, color=color, xdim=xdim)

--- a/eelbrain/plot/uts.py
+++ b/eelbrain/plot/uts.py
@@ -339,10 +339,10 @@ def _ax_stat(ax, ct, colors, legend_h={},
 
 
 class clusters(_base.subplot_figure):
-    def __init__(self, epochs, pmax=0.05, ptrend=0.1, t=True,
+    def __init__(self, epochs, pmax=0.05, ptrend=0.1, t=True, ls = 'solid', 
                  title="plot.uts.clusters", figtitle=None, axtitle='{name}',
                  cm=_cm.jet, width=6, height=3, frame=.1, dpi=90,
-                 overlay=False):
+                 tcolor = 'k', overlay=False):
         """
         Specialized plotting function for Permutation Cluster test results
 
@@ -352,11 +352,15 @@ class clusters(_base.subplot_figure):
             Maximum p-value of clusters to plot as trend.
         t : bool
             Plot threshold for forming clusters.
+        ls : str
+            Line style. e.g. [‘solid’ | ‘dashed’ | ‘dashdot’ | ‘dotted’]
+        tcolor : str
+            Line color for threshold.
         title : str
             Window title.
         figtitle : str | None
             Figure title.
-        axtitle : str | Nonw
+        axtitle : str | None
             Axes title pattern. '{name}' is formatted to the first layer's
             name
         overlay : bool
@@ -399,7 +403,8 @@ class clusters(_base.subplot_figure):
             # color
             color = cm(i / N)
             cax = _ax_clusters(ax, layers, color=color, pmax=pmax, t=t,
-                               title=title_, ptrend=ptrend)
+                               tcolor = tcolor, ls = ls, title=title_, 
+                               ptrend=ptrend)
             self._caxes.append(cax)
 
         self._show(figtitle=figtitle)
@@ -477,7 +482,8 @@ def _plt_uts(ax, layer, color=None, xdim='time', kwargs={}):
 
 class _ax_clusters:
     def __init__(self, ax, layers, color=None, pmax=0.05, ptrend=0.1,
-                 t=True, xdim='time', title=None):
+                 t=True, ls = 'solid', tcolor = tcolor, xdim='time', 
+                 title=None):
         Y = layers[0]
 
         if title:
@@ -488,7 +494,7 @@ class _ax_clusters:
         if t is True:
             t = Y.properties.get('threshold', None)
         if t:
-            ax.axhline(t, color='k')
+            ax.axhline(t, color = tcolor, ls = ls)
         ylabel = Y.properties.get('unit', None)
 
         _plt_uts(ax, Y, color=color, xdim=xdim)

--- a/eelbrain/vessels/experiment.py
+++ b/eelbrain/vessels/experiment.py
@@ -152,7 +152,7 @@ class mne_experiment(object):
 
         # set initial values
         for k, v in self.var_values.iteritems():
-            if k:
+            if v:
                 self.state[k] = v[0]
 
         # set defaults for any existing templates

--- a/eelbrain/vessels/experiment.py
+++ b/eelbrain/vessels/experiment.py
@@ -152,7 +152,8 @@ class mne_experiment(object):
 
         # set initial values
         for k, v in self.var_values.iteritems():
-            self.state[k] = v[0]
+            if k:
+                self.state[k] = v[0]
 
         # set defaults for any existing templates
         for k in self.state.keys():


### PR DESCRIPTION
Hey,

The plot modification is to incorporate a dict as a kwarg for the plot.uts.clusters. It seems to be alright.

The experiment modification as the option to not iterate over empty list. e.g. I don't have an experiments class attribute so when it goes to set initial values, it raises an error b/c the iteration is said to be out of range (since the experiment = [ ] ).

In the fiff modification, the kwarg dict retains the tstart and tstop entries, which is problematic when being forwarded to the mne.Epochs class. Since these kwargs are being reassigned to tmin and tmax, I just remove them after assignment.

Let me know if you have any questions.
