### PR TITLE
FIX MneExperiment.load_evoked_stc(): check that mask is boolean

### DIFF
--- a/eelbrain/_experiment/mne_experiment.py
+++ b/eelbrain/_experiment/mne_experiment.py
@@ -2739,6 +2739,8 @@ class MneExperiment(FileTree):
             raise NotImplementedError("post_baseline_trigger_shift is not "
                                       "implemented for baseline correction in "
                                       "source space")
+        if mask and not isinstance(mask, bool):
+            raise TypeError("mask must be boolean, got %s" % repr(mask))
 
         ds = self.load_evoked(subject, sns_baseline, sns_ndvar, cat, None,
                               data_raw, **kwargs)
@@ -4577,7 +4579,7 @@ class MneExperiment(FileTree):
             res = self._make_test(ds[label_keys[label]], ds, test, test_kwargs,
                                   do_mcc)
             label_results[label] = res
-            
+
         if do_mcc:
             cdists = [r._cdist for r in label_results.values()]
             merged_dist = _MergedTemporalClusterDist(cdists)


### PR DESCRIPTION
Prevents one from passing the parcellation name as the mask and becoming confused at the results.