### PR TITLE
FIX NDVar.bin(): correct number of bins

### DIFF
--- a/eelbrain/_data_obj.py
+++ b/eelbrain/_data_obj.py
@@ -3626,7 +3626,7 @@ class NDVar(object):
             if stop is None:
                 stop = dim.tstop
 
-            n_bins = int(ceil((stop - start) / step))
+            n_bins = int(ceil(round(((stop - start) / step), 2)))
             out_dim = UTS(start + step / 2, step, n_bins)
         elif isinstance(dim, Ordered):
             if start is None:

--- a/eelbrain/tests/test_data.py
+++ b/eelbrain/tests/test_data.py
@@ -911,6 +911,11 @@ def test_ndvar_binning():
     assert_array_equal(binned_ndvar.x, 1.)
     eq_(binned_ndvar.shape, (5, 7))
 
+    # n_bins
+    x = np.ones((5, 601))
+    ndvar = NDVar(x, ('case', UTS(-0.1, 0.001, 601)))
+    binned_ndvar = ndvar.bin(0.1, 0.1, 0.4)
+    eq_(binned_ndvar.shape, (5, 3))
 
 def test_ndvar_graph_dim():
     "Test NDVar dimensions with conectvity graph"


### PR DESCRIPTION
**Summary**: Rounding the value of `(stop - start) / step` before getting the ceiling fixes floating point errors that caused too many bins.

Noticed that binning a UTS with certain values for `tstart`/`tstop` raised ValueErrors that `tstart` needed to be less than `tstop`. Example:
```python
nd = NDVar(np.random.rand(10, 601), dims=('case', UTS(-0.1, 0.001, 601)))
nd.bin(step=0.1, start=0.1, stop=0.4)
```
Found the issue to be that `(0.4 - 0.1) / 0.1)` evaluates to `3.0000000000000004`, the ceiling of which is 4, resulting in one too many bins. I added a rounding step (to the hundredths place) before computing the ceiling.
