### PR TITLE
allow parsing 'vol-10' correctly

### DIFF
--- a/eelbrain/_data_obj.py
+++ b/eelbrain/_data_obj.py
@@ -8434,7 +8434,7 @@ class SourceSpace(Dimension):
 
     def _init_secondary(self):
         self._n_vert = sum(len(v) for v in self.vertices)
-        match = re.match("(ico|vol)-(\d)", self.src)
+        match = re.match("(ico|vol)-(10|\d)", self.src)
         # The source-space type is needed to determine connectivity
         if match is None:
             raise ValueError("src=%r; needs to be 'ico-i' or 'vol-i'" % self.src)


### PR DESCRIPTION
It could not read the grade correctly, because from 'vol-10' src it reads kind = 'vol' and grade='1' instead of '10'. Fixed this.