### PR TITLE
FIX Avoid divide by zero in vector.pyx

### DIFF
--- a/eelbrain/_stats/vector.pyx
+++ b/eelbrain/_stats/vector.pyx
@@ -145,11 +145,12 @@ def t2_stat(cnp.ndarray[FLOAT64, ndim=3] y,
             temp = 0
             for u in range(n_dims):
                 temp += vec[u][v] * mean[u]
-            if eig[v] > TOL:
-                norm += temp ** 2 / eig[v]
-            else:
-                # norm += 0
-                norm += temp ** 2 / TOL
+            if temp != 0.0:     # Avoid divide by zero
+                if eig[v] > TOL:
+                    norm += temp ** 2 / eig[v]
+                else:
+                    # norm += 0
+                    norm += temp ** 2 / TOL
         out[i] = norm ** 0.5
     return out
 
@@ -201,11 +202,12 @@ def t2_stat_rotated(cnp.ndarray[FLOAT64, ndim=3] y,
             temp = 0
             for u in range(n_dims):
                 temp += vec[u][v] * mean[u]
-            if eig[v] > TOL:
-                norm += temp ** 2 / eig[v]
-            else:
-                # norm += 0
-                norm += temp ** 2 / TOL
+            if temp != 0.0:  # Avoid divide by zero
+                if eig[v] > TOL:
+                    norm += temp ** 2 / eig[v]
+                else:
+                    # norm += 0
+                    norm += temp ** 2 / TOL
         out[i] = norm ** 0.5
     return out
 

--- a/eelbrain/tests/test_mne.py
+++ b/eelbrain/tests/test_mne.py
@@ -314,7 +314,7 @@ def test_vec_source():
     # test
     res = testnd.Vector('src', ds=ds, samples=2)
     clusters = res.find_clusters()
-    assert_array_equal(clusters['n_sources'], [1, 719, 1, 11, 4])
+    assert_array_equal(clusters['n_sources'], [799, 1, 7, 1, 2, 1])
     # NDVar
     v = ds['src']
     assert v.sub(source='lh', time=0).shape == (72, 712, 3)


### PR DESCRIPTION
Hey, looks like the previous version did not take care of all zero case in t2 test. Fixing that with this PR.