### PR TITLE
Fix Issue #78 - ctf275 channel name mismatch

### DIFF
--- a/eelbrain/_io/fiff.py
+++ b/eelbrain/_io/fiff.py
@@ -784,7 +784,8 @@ def sensor_dim(
                 if ' ' not in names[0]:  # mne-python < ~1.2
                     names = [f'{n[:3]} {n[3:]}' for n in names]
             elif connectivity == 'ctf275':
-                names = [f'{name}-4408' for name in names]
+                suffix = ch_names[0][-5:]
+                names = [f'{name}{suffix}' for name in names]
             elif connectivity.startswith('bti'):
                 names = [f'MEG {name[1:]:0>3}' for name in names]
 

--- a/eelbrain/_io/fiff.py
+++ b/eelbrain/_io/fiff.py
@@ -784,8 +784,7 @@ def sensor_dim(
                 if ' ' not in names[0]:  # mne-python < ~1.2
                     names = [f'{n[:3]} {n[3:]}' for n in names]
             elif connectivity == 'ctf275':
-                suffix = ch_names[0][-5:]
-                names = [f'{name}{suffix}' for name in names]
+                ch_names = [name[:5] for name in ch_names]
             elif connectivity.startswith('bti'):
                 names = [f'MEG {name[1:]:0>3}' for name in names]
 

--- a/eelbrain/_io/fiff.py
+++ b/eelbrain/_io/fiff.py
@@ -784,7 +784,8 @@ def sensor_dim(
                 if ' ' not in names[0]:  # mne-python < ~1.2
                     names = [f'{n[:3]} {n[3:]}' for n in names]
             elif connectivity == 'ctf275':
-                ch_names = [name[:5] for name in ch_names]
+                suffix = ch_names[0][-5:]
+                names = [f'{name}{suffix}' for name in names]
             elif connectivity.startswith('bti'):
                 names = [f'MEG {name[1:]:0>3}' for name in names]
 

--- a/eelbrain/_io/fiff.py
+++ b/eelbrain/_io/fiff.py
@@ -784,7 +784,7 @@ def sensor_dim(
                 if ' ' not in names[0]:  # mne-python < ~1.2
                     names = [f'{n[:3]} {n[3:]}' for n in names]
             elif connectivity == 'ctf275':
-                ch_names = [name[:5] for name in ch_names]
+                names = [f'{name}-4408' for name in names]
             elif connectivity.startswith('bti'):
                 names = [f'MEG {name[1:]:0>3}' for name in names]
 


### PR DESCRIPTION
Addresses issue #78. Changed to not remove the '-####' suffix on channel names when generating a Sensor dimension, and instead adds the suffix to the names generated from finding the adjacencies, so the two match.

Passes pytest in test files within the _io folder