### PR TITLE
MAINT add pyproject.toml

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -13,24 +13,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
+    # - name: Set up Python 3.10
+    #   uses: actions/setup-python@v3
+    #   with:
+    #     python-version: '3.10'
     - if: matrix.os == 'ubuntu-latest'
       name: Install dependencies
       run: |
         sudo apt-get update
-    - name: Install Mamba
+    - name: Use Mamba to create env
       uses: mamba-org/setup-micromamba@v2
       with:
-        environment-file: env-dev.yml
         environment-name: eeldev
+        create-args: >-
+          python=3.10
+          libcblas
+          numpy>=1.20
+          wxpython>=4.1.0
+          rpy2
+          r-car
         init-shell: bash
         cache-environment: true
         post-cleanup: 'all'
-    - name: build Eelbrain
-      run: pip install -e .
+    - name: Build eelbrain
+      run: pip install -e .[all]
       shell: bash -el {0}
     - if: matrix.os == 'ubuntu-latest'
       name: Test without GUI

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -13,10 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    # - name: Set up Python 3.10
-    #   uses: actions/setup-python@v3
-    #   with:
-    #     python-version: '3.10'
     - if: matrix.os == 'ubuntu-latest'
       name: Install dependencies
       run: |
@@ -24,14 +20,8 @@ jobs:
     - name: Use Mamba to create env
       uses: mamba-org/setup-micromamba@v2
       with:
+        environment-file: env-dev.yml
         environment-name: eeldev
-        create-args: >-
-          python=3.10
-          libcblas
-          numpy>=1.20
-          wxpython>=4.1.0
-          rpy2
-          r-car
         init-shell: bash
         cache-environment: true
         post-cleanup: 'all'

--- a/eelbrain/datasets/_alice.py
+++ b/eelbrain/datasets/_alice.py
@@ -1,9 +1,7 @@
 # Helper to download data for Alice example
-import os
-import pooch
-
 from pathlib import Path
-import zipfile
+
+import pooch
 
 from .._types import PathArg
 
@@ -14,17 +12,7 @@ def get_alice_path(
     path = Path(path).expanduser().resolve()
     if not path.exists():
         path.mkdir(exist_ok=True, parents=True)
-    urls = [
-        ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/stimuli.zip', '92317dbfc81d6aef14fc334abd75d1165cf57501f0c11f8db1a47c76c3d90ac6'],
-        # ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.0.zip', 'd63d96a6e5080578dbf71320ddbec0a0'],
-        ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.1.zip', 'a645e4bf30ec8de10c92f82e9f842dd8172a4871f8eb23244e7e78b7dff157aa'],  # S15-S34
-        # ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.2.zip', '3fb33ca1c4640c863a71bddd45006815'],
-    ]
-    # for url, known_hash in urls:
-        # temp_file_path = pooch.retrieve(url, known_hash, progressbar=True)
-        # with zipfile.ZipFile(temp_file_path, 'r') as f:
-        #     f.extractall(path)
-        # os.remove(temp_file_path)
+
     baseurl = 'https://drum.lib.umd.edu/bitstream/handle/1903/27591/'
     registry = {
         'stimuli.zip': '92317dbfc81d6aef14fc334abd75d1165cf57501f0c11f8db1a47c76c3d90ac6',
@@ -37,6 +25,8 @@ def get_alice_path(
         retry_if_failed=4,
     )
     for fname in registry.keys():
-        fetcher.fetch(fname, progressbar=True, processor=pooch.Unzip(extract_dir='.'))
-        os.remove(path / fname)
+        if (path / fname.split('.')[0]).exists():   # Won't work for multiple eeg.x.zip download
+            continue
+        fetcher.fetch(fname, processor=pooch.Unzip(extract_dir='.'))
+        (path / fname).unlink()
     return path

--- a/eelbrain/datasets/_alice.py
+++ b/eelbrain/datasets/_alice.py
@@ -12,19 +12,31 @@ def get_alice_path(
         path: PathArg = Path("~/Data/Alice"),
 ):
     path = Path(path).expanduser().resolve()
-    if path.exists():
-        return path
-    path.mkdir(exist_ok=True, parents=True)
+    if not path.exists():
+        path.mkdir(exist_ok=True, parents=True)
     urls = [
         ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/stimuli.zip', '92317dbfc81d6aef14fc334abd75d1165cf57501f0c11f8db1a47c76c3d90ac6'],
         # ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.0.zip', 'd63d96a6e5080578dbf71320ddbec0a0'],
         ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.1.zip', 'a645e4bf30ec8de10c92f82e9f842dd8172a4871f8eb23244e7e78b7dff157aa'],  # S15-S34
         # ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.2.zip', '3fb33ca1c4640c863a71bddd45006815'],
     ]
-
-    for url, known_hash in urls:
-        temp_file_path = pooch.retrieve(url, known_hash)
-        with zipfile.ZipFile(temp_file_path, 'r') as f:
-            f.extractall(path)
-        os.remove(temp_file_path)
+    # for url, known_hash in urls:
+        # temp_file_path = pooch.retrieve(url, known_hash, progressbar=True)
+        # with zipfile.ZipFile(temp_file_path, 'r') as f:
+        #     f.extractall(path)
+        # os.remove(temp_file_path)
+    baseurl = 'https://drum.lib.umd.edu/bitstream/handle/1903/27591/'
+    registry = {
+        'stimuli.zip': '92317dbfc81d6aef14fc334abd75d1165cf57501f0c11f8db1a47c76c3d90ac6',
+        'eeg.1.zip': 'a645e4bf30ec8de10c92f82e9f842dd8172a4871f8eb23244e7e78b7dff157aa'
+    }
+    fetcher = pooch.Pooch(
+        path=path,
+        base_url=baseurl,
+        registry=registry,
+        retry_if_failed=4,
+    )
+    for fname in registry.keys():
+        fetcher.fetch(fname, progressbar=True, processor=pooch.Unzip(extract_dir='.'))
+        os.remove(path / fname)
     return path

--- a/eelbrain/datasets/_alice.py
+++ b/eelbrain/datasets/_alice.py
@@ -1,11 +1,9 @@
 # Helper to download data for Alice example
-import hashlib
-import shutil
-from pathlib import Path
-from urllib.request import urlretrieve
-import zipfile
+import os
+import pooch
 
-from pooch import file_hash
+from pathlib import Path
+import zipfile
 
 from .._types import PathArg
 
@@ -13,28 +11,20 @@ from .._types import PathArg
 def get_alice_path(
         path: PathArg = Path("~/Data/Alice"),
 ):
-    md5 = hashlib.md5()
-
     path = Path(path).expanduser().resolve()
     if path.exists():
         return path
     path.mkdir(exist_ok=True, parents=True)
     urls = [
-        ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/stimuli.zip', '4336a47bef7d3e63239c40c0623dc186'],
+        ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/stimuli.zip', '92317dbfc81d6aef14fc334abd75d1165cf57501f0c11f8db1a47c76c3d90ac6'],
         # ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.0.zip', 'd63d96a6e5080578dbf71320ddbec0a0'],
-        ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.1.zip', 'bdc65f168db4c0f19bb0fed20eae129b'],  # S15-S34
+        ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.1.zip', 'a645e4bf30ec8de10c92f82e9f842dd8172a4871f8eb23244e7e78b7dff157aa'],  # S15-S34
         # ['https://drum.lib.umd.edu/bitstream/handle/1903/27591/eeg.2.zip', '3fb33ca1c4640c863a71bddd45006815'],
     ]
 
-    for url, hash in urls:
-        temp_file_path, header = urlretrieve(url)
-        # with open(temp_file_path, "rb") as f:
-        #     for chunk in iter(lambda: f.read(1048576), b""):
-        #         md5.update(chunk)
-        # file_hash = md5.hexdigest()
-        # if file_hash != hash:
-        #     raise RuntimeError(f'Hash mismatch for {url}: {file_hash} != {hash}')
+    for url, known_hash in urls:
+        temp_file_path = pooch.retrieve(url, known_hash)
         with zipfile.ZipFile(temp_file_path, 'r') as f:
             f.extractall(path)
-        Path(temp_file_path).unlink()
+        os.remove(temp_file_path)
     return path

--- a/eelbrain/datasets/_alice.py
+++ b/eelbrain/datasets/_alice.py
@@ -10,8 +10,7 @@ def get_alice_path(
         path: PathArg = Path("~/Data/Alice"),
 ):
     path = Path(path).expanduser().resolve()
-    if not path.exists():
-        path.mkdir(exist_ok=True, parents=True)
+    path.mkdir(exist_ok=True, parents=True)
 
     baseurl = 'https://drum.lib.umd.edu/bitstream/handle/1903/27591/'
     registry = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,121 @@
+[build-system]
+requires = [
+    "setuptools >= 64.0.0",
+    "numpy >= 1.20",
+    "cython >= 3",
+    ]
+build-backend = "setuptools.build_meta"
+
+[project]
+authors = [
+  {email = 'christianbrodbeck@nyu.edu', name = 'Christian Brodbeck'},
+]
+classifiers = [
+  'Natural Language :: English',
+  'Operating System :: MacOS',
+  'Operating System :: Microsoft :: Windows',
+  'Operating System :: Unix',
+  'Programming Language :: Python :: 3 :: Only',
+  'Programming Language :: Python :: 3.10',
+  'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.9',
+]
+dependencies = [
+  'appnope',
+  'colormath >= 2.1',
+  'keyring >= 5',
+  'libclang',
+  'matplotlib >= 3.6',
+  'mne >= 1',
+  'nibabel >= 2.5',
+  'numpy >= 1.20',
+  'pillow',
+  'psutils',
+  'pymatreader',
+  'scipy >= 1.5',
+  'seaborn',
+]
+description='MEG/EEG analysis tools'
+keywords = [
+  'ant neuro',
+  'cnt',
+  'eeg',
+  'eego',
+  'python',
+]
+license = 'BSD-3-Clause'
+license-files = ['LICENSE.txt']
+maintainers = [
+  {email = 'christianbrodbeck@nyu.edu', name = 'Chrsitian Brodbeck'},
+  {name = 'Proloy Das'},
+]
+name = 'eelbrain'
+readme = 'README.md'
+requires-python = '>=3.8'
+dynamic = ["version"]
+
+[project.optional-dependencies]
+all = [
+  'eelbrain[full]',
+  'eelbrain[test]',
+]
+brain = [
+  'pysurfer[save_movie]',
+  'nilearn >=0.10.4'
+]
+gui = [
+    'ipdb',
+    'ipython',
+    'colormath >= 2.1',
+    'tqdm >= 4.40',
+    'wxpython >= 4.0.3, != 4.1.0',
+]
+full = [
+  'eelbrain[brain]',   
+  'eelbrain[gui]',
+]
+style = [
+  'codespell[toml] >= 2.2.4',
+  'ruff >= 0.6.0',
+  'toml-sort',
+  'yamllint',
+]
+doc = [
+  'sphinx >= 3',
+  'sphinx-gallery',
+  'sphinx_rtd_theme',
+  'sphinxcontrib-bibtex',
+  'pydocstyle',
+  'pingouin'
+]
+test = [
+  'flake8',
+  'pytest-cov',
+  'pytest >=8.0, < 8.1.1',
+  'pytest-faulthandler',
+  'pingouin'
+]
+
+[tool.tomlsort]
+all = true
+ignore_case = true
+spaces_before_inline_comment = 2
+trailing_comma_inline_array = true
+
+[project.urls]
+documentation = 'https://eelbrain.readthedocs.io'
+homepage = 'https://eelbrain.readthedocs.io'
+source = 'https://github.com/Eelbrain/eelbrain'
+tracker = 'https://github.com/Eelbrain/eelbrain/issues'
+
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.packages.find]
+exclude = ['eelbrain*tests']
+include = ['eelbrain*']
+
+[tool.setuptools.dynamic]
+version = {attr = "eelbrain.__version__"}

--- a/setup.py
+++ b/setup.py
@@ -19,16 +19,6 @@ except ImportError:
 
 IS_WINDOWS = os.name == 'nt'
 IS_ARM = platform.machine().lower().startswith('arm')
-this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
-
-# version must be in X.X.X format, e.g., "0.0.3dev"
-text = (this_directory / 'eelbrain' / '__init__.py').read_text()
-match = re.search(r"__version__ = '([.\w]+)'", text)
-if match is None:
-    raise ValueError("No valid version string found in:\n\n" + text)
-version = match.group(1)
-Version(version)  # check that it's a valid version
 
 # Cython extensions
 base_args = {'define_macros': [("NPY_NO_DEPRECATED_API", "NPY_1_11_API_VERSION")]}
@@ -40,8 +30,8 @@ if IS_WINDOWS:
 elif IS_ARM:
     open_mp_args = {
         **base_args,
-        'extra_compile_args': ['-Wno-unreachable-code', '-fopenmp', '-O3'],
-        'extra_link_args': ['-fopenmp'],
+        'extra_compile_args': ['-Wno-unreachable-code', '-Xpreprocessor', '-fopenmp', '-O3'],
+        'extra_link_args': ['-Xpreprocessor', '-fopenmp'],
     }
     base_args['extra_compile_args'] = ['-Wno-unreachable-code', '-O3']
 else:
@@ -66,45 +56,6 @@ if cythonize:
     extensions = cythonize(extensions)
 
 setup(
-    name='eelbrain',
-    version=version,
-    description="MEG/EEG analysis tools",
-    url="https://eelbrain.readthedocs.io",
-    author="Christian Brodbeck",
-    author_email='christianbrodbeck@nyu.edu',
-    license='BSD (3-clause)',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    python_requires='>=3.8',
-    setup_requires=[
-        "numpy >= 1.20",
-        "cython >= 3",
-    ],
-    install_requires=[
-        'appnope',
-        'colormath >= 2.1',
-        'keyring >= 5',
-        'matplotlib >= 3.6',
-        'mne >= 0.19',
-        'nibabel >= 2.5',
-        'numpy >= 1.20',
-        'pillow',
-        'pymatreader',
-        'scipy >= 1.5',
-        'tqdm >= 4.40',
-    ],
-    extras_require={
-        'brain': [
-            'pysurfer[save_movie]',
-        ],
-        'gui': [
-            'wxpython > 4.1.0',
-        ],
-        'full': [
-            'pysurfer[save_movie]',
-            'wxpython > 4.1.0',
-        ],
-    },
     include_dirs=[np.get_include()],
     packages=find_packages(),
     ext_modules=extensions,


### PR DESCRIPTION
Add `pyproject.toml` to modernize build process.

NOTE: setup.py is not defunct, in fact, it does the heavy lifting for creating the C-extensions as before. Only the ornamental information and build/installation requirements  were moved to `pyproject.toml`.