### PR TITLE
fix Pipeline bad channel handling

### DIFF
--- a/eelbrain/_experiment/mne_experiment.py
+++ b/eelbrain/_experiment/mne_experiment.py
@@ -4048,7 +4048,7 @@ class Pipeline(FileTree):
         merge_bad_channels : merge bad channel definitions for all tasks
         """
         pipe = self._raw[self.get('raw', **kwargs)]
-        pipe.make_bad_channels(self._bids_path, bad_chs, override=redo)
+        pipe.make_bad_channels(self._bids_path, bad_chs, redo=redo)
 
     def make_bad_channels_auto(self, flat=None, redo=False, **state):
         """Automatically detect bad channels
@@ -4068,7 +4068,7 @@ class Pipeline(FileTree):
         if state:
             self.set(**state)
         pipe = self._raw['raw']
-        pipe.make_bad_channels_auto(self._bids_path, flat, override=redo)
+        pipe.make_bad_channels_auto(self._bids_path, flat, redo=redo)
 
     def make_bad_channels_neighbor_correlation(
             self,

--- a/eelbrain/_experiment/preprocessing.py
+++ b/eelbrain/_experiment/preprocessing.py
@@ -277,8 +277,10 @@ class RawSource(RawPipe):
         bads_path = self._bads_path(path)
         if exists(bads_path):
             channels_df = pd.read_csv(bads_path, sep='\t')
-            if not {'name', 'status'}.issubset(channels_df.columns.tolist()):
-                raise RuntimeError(f"channels.tsv file at {bads_path} is missing required column 'name' or 'status'. Please delete the file and regenerate it.")
+            if 'status' not in channels_df.columns:
+                return []
+            elif 'name' not in channels_df.columns:
+                raise RuntimeError(f"channels.tsv file at {bads_path} is missing required column 'name'. Please regenerate the file.")
             return channels_df.query('status == "bad"')['name'].tolist()
         # create channels file
         self.log.info("No channels.tsv found for %s, creating an empty one.", path.fpath)

--- a/eelbrain/_experiment/preprocessing.py
+++ b/eelbrain/_experiment/preprocessing.py
@@ -125,7 +125,7 @@ class RawPipe:
             self,
             path: BIDSPath,
             bad_chs: Union[Tuple[str], str, int],
-            override: bool,
+            redo: bool,
     ) -> None:
         raise NotImplementedError
 
@@ -133,7 +133,7 @@ class RawPipe:
             self,
             path: BIDSPath,
             flat: float,
-            override: bool,
+            redo: bool,
     ) -> None:
         raise NotImplementedError
 
@@ -302,7 +302,7 @@ class RawSource(RawPipe):
             self,
             path: BIDSPath,
             bad_chs: Union[Tuple[str], str, int],
-            override: bool,
+            redo: bool,
     ) -> None:
         # check input list
         if isinstance(bad_chs, (str, int)):
@@ -312,14 +312,14 @@ class RawSource(RawPipe):
         new_bads = sensor._normalize_sensor_names(bad_chs)
         # merge with old bads
         old_bads = self.load_bad_channels(path)
-        if old_bads is not None and not override:
+        if old_bads is not None and not redo:
             new_bads = sorted(set(old_bads).union(new_bads))
         # print change
         print(f"{old_bads} -> {new_bads}")
         if new_bads == old_bads:
             return
         # write new bad channels
-        if override:
+        if redo:
             mark_channels(path, ch_names='all', status='good', verbose=MNE_VERBOSITY)
         mark_channels(path, ch_names=new_bads, status='bad', verbose=MNE_VERBOSITY)
 
@@ -327,7 +327,7 @@ class RawSource(RawPipe):
             self,
             path: BIDSPath,
             flat: float = None,
-            override: bool = False,
+            redo: bool = False,
     ) -> None:
         if flat is None:
             if path.datatype == 'meg':
@@ -343,7 +343,7 @@ class RawSource(RawPipe):
         sysname = self.get_sysname(raw.info, path.subject, None)
         raw = load.mne.raw_ndvar(raw, sysname=sysname, adjacency=self.adjacency)
         bad_chs.extend(raw.sensor.names[raw.std('time') < flat])
-        self.make_bad_channels(path, bad_chs, override)
+        self.make_bad_channels(path, bad_chs, redo)
 
     def _as_dict(self, args: Sequence[str] = ()) -> dict:
         out = RawPipe._as_dict(self, args)
@@ -490,9 +490,9 @@ class CachedRawPipe(RawPipe):
             self,
             path: BIDSPath,
             bad_chs: Union[Tuple[str], str, int],
-            override: bool,
+            redo: bool,
     ) -> None:
-        self.source.make_bad_channels(path, bad_chs, override)
+        self.source.make_bad_channels(path, bad_chs, redo)
 
     def make_bad_channels_auto(self, *args, **kwargs) -> None:
         self.source.make_bad_channels_auto(*args, **kwargs)

--- a/eelbrain/_experiment/preprocessing.py
+++ b/eelbrain/_experiment/preprocessing.py
@@ -321,7 +321,8 @@ class RawSource(RawPipe):
         # write new bad channels
         if redo:
             mark_channels(path, ch_names='all', status='good', verbose=MNE_VERBOSITY)
-        mark_channels(path, ch_names=new_bads, status='bad', verbose=MNE_VERBOSITY)
+        if len(new_bads):
+            mark_channels(path, ch_names=new_bads, status='bad', verbose=MNE_VERBOSITY)
 
     def make_bad_channels_auto(
             self,

--- a/eelbrain/_experiment/tests/test_sample_experiment.py
+++ b/eelbrain/_experiment/tests/test_sample_experiment.py
@@ -346,6 +346,8 @@ def test_sample_tasks():
     e.make_bad_channels('MEG 0121')
     assert e.load_bad_channels() == ['MEG 0111', 'MEG 0121']
     # redo bad channels
+    e.make_bad_channels([], redo=True)
+    assert e.load_bad_channels() == []
     e.make_bad_channels('MEG 0111', redo=True)
     assert e.load_bad_channels() == ['MEG 0111']
 


### PR DESCRIPTION
- Pre-existing bad channels file that are missing a status column can be treated as all good
- Fix a bug where make_bad_channels([], redo=True) lead to marking all channels as bad  