### PR TITLE
CI:  update codecov upload

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -51,4 +51,3 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        verbose: true  # optional (default = false)

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -48,6 +48,7 @@ jobs:
         pytest eelbrain --cov --cov-branch --cov-report=xml
     - if: matrix.os == 'macos-latest'
       name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true  # optional (default = false)


### PR DESCRIPTION
@zhangwenchili I noticed there is now v5 (https://github.com/codecov/codecov-action)

re-added the secret on https://github.com/Eelbrain/Eelbrain

