### PR TITLE
FEATURE support 2D vector fields in testnd.Vector

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -20,6 +20,13 @@ Issues on prior versions
 
 Major changes
 =============
+New in 0.42
+-----------
+
+  * Permutation tests:
+    - Now ``testnd.Vector()`` supports 2D vector fields (e.g., complex valued phase amplitude data) in addition to 3D vector fields (e.g., 3D source space data). The test will automatically determine the appropriate randomization scheme based on the dimensionality of the input data.
+    - Due to a bug fix in stats computation, the permutation distribution for vector-based tests may be slightly different.
+
 
 New in 0.41
 -----------
@@ -35,6 +42,7 @@ New in 0.41
 
       - ``eelbrain.Sensor.get_connectivity()`` →  :meth:`eelbrain.Sensor.get_adjacency`
       - ``eelbrain.Sensor.set_connectivity()`` →  :meth:`eelbrain.Sensor.set_adjacency`
+
 
 New in 0.40
 -----------

--- a/eelbrain/_stats/permutation.py
+++ b/eelbrain/_stats/permutation.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from .._data_obj import NDVar, Var, NestedEffect
 from .._utils import intervals
-from . import vector
+from . import vector3d
 
 
 _YIELD_ORIGINAL = 0
@@ -258,7 +258,18 @@ def _sample_xi_by_rejection(n: int, rng: np.random.RandomState):
     return samples
 
 
-def rand_rotation_matrices(n: int, seed: int):
+def rand_rotation_matrices(n: int, seed: int, dim: int):
+    if dim > 3:
+        raise NotImplementedError(f"dim={dim} is not supported!")
+    elif dim == 3:
+        return rand_rotation_matrices_3d(n, seed)
+    elif dim == 2:
+        return rand_rotation_matrices_2d(n, seed)
+    else:
+        raise ValueError(f"dim={dim} does not have rotation.")
+
+
+def rand_rotation_matrices_3d(n: int, seed: int):
     """Function to create random rotation matrices in 3D
 
     Parameters
@@ -277,4 +288,29 @@ def rand_rotation_matrices(n: int, seed: int):
     phi = np.arccos(rng.uniform(-1, 1, n))
     theta = rng.uniform(0, 2 * pi, n)
     xi = _sample_xi_by_rejection(n, rng)
-    return vector.rotation_matrices(phi, theta, xi, np.empty((n, 3, 3)))
+    return vector3d.rotation_matrices(phi, theta, xi, np.empty((n, 3, 3)))
+
+
+def rand_rotation_matrices_2d(n: int, seed: int):
+    """Function to create random rotation matrices in 3D
+
+    Parameters
+    ----------
+    n : int
+        Number of rotation matrices to return.
+    seed : int
+        Seed the random state.
+
+    Returns
+    -------
+    rotation : array (n, 2, 2)
+        Sampled rotation matrices.
+    """
+    rng = np.random.RandomState(seed)
+    thetas = rng.uniform(0, 2 * pi, n)
+    rot_mat = np.empty((n, 2, 2))
+    np.cos(thetas, out=rot_mat[:, 0, 0])
+    np.sin(thetas, out=rot_mat[:, 0, 1])
+    rot_mat[:, 1, 0] = - rot_mat[:, 0, 1]
+    rot_mat[:, 1, 1] = rot_mat[:, 0, 0]
+    return rot_mat

--- a/eelbrain/_stats/permutation.py
+++ b/eelbrain/_stats/permutation.py
@@ -260,13 +260,13 @@ def _sample_xi_by_rejection(n: int, rng: np.random.RandomState):
 
 def rand_rotation_matrices(n: int, seed: int, dim: int):
     if dim > 3:
-        raise NotImplementedError(f"dim={dim} is not supported!")
+        raise NotImplementedError(f"{dim=} is not supported!")
     elif dim == 3:
         return rand_rotation_matrices_3d(n, seed)
     elif dim == 2:
         return rand_rotation_matrices_2d(n, seed)
     else:
-        raise ValueError(f"dim={dim} does not have rotation.")
+        raise ValueError(f"{dim=} does not have rotation.")
 
 
 def rand_rotation_matrices_3d(n: int, seed: int):

--- a/eelbrain/_stats/stats.py
+++ b/eelbrain/_stats/stats.py
@@ -12,6 +12,7 @@ import scipy.stats
 from scipy.linalg import inv
 
 from .._data_obj import CategorialArg, CellArg, Dataset, FactorArg, Model, Parametrization, asarray, ascategorial, asfactor, asmodel
+from .._exceptions import WrongDimensionError
 from . import opt, vector
 
 
@@ -336,7 +337,7 @@ def t2_1samp(y, rotation=None, out=None):
     n_cases = y.shape[0]
     n_dims = y.shape[1]
     if n_dims <= 1 or n_dims > 3:
-        raise ValueError(f'y with shape {y.shape}: T**2 statistic needs 2d/3d vector valued samples.')
+        raise WrongDimensionError(f'y with shape {y.shape}: T**2 statistic needs 2d/3d vector valued samples.')
 
     if out is None:
         out = np.empty(y.shape[2:])

--- a/eelbrain/_stats/stats.py
+++ b/eelbrain/_stats/stats.py
@@ -12,8 +12,7 @@ import scipy.stats
 from scipy.linalg import inv
 
 from .._data_obj import CategorialArg, CellArg, Dataset, FactorArg, Model, Parametrization, asarray, ascategorial, asfactor, asmodel
-from . import opt
-from . import vector
+from . import opt, vector
 
 
 FLOAT64 = np.dtype('float64')
@@ -334,10 +333,11 @@ def t2_1samp(y, rotation=None, out=None):
     out : ndarray
         Container for result. Needs shape ``...``.
     """
-    if y.ndim <= 1:
-        raise ValueError(f'y with shape {y.shape}: T**2 statistic needs vector valued samples.')
     n_cases = y.shape[0]
     n_dims = y.shape[1]
+    if n_dims <= 1 or n_dims > 3:
+        raise ValueError(f'y with shape {y.shape}: T**2 statistic needs 2d/3d vector valued samples.')
+
     if out is None:
         out = np.empty(y.shape[2:])
     else:
@@ -351,10 +351,10 @@ def t2_1samp(y, rotation=None, out=None):
         out_flat = out.ravel()
 
     if rotation is None:
-        vector.t2_stat(y_flat, out_flat)
+        vector.t2_stat(y_flat, out_flat, n_dims)
     else:
-        assert rotation.shape == (n_cases, 3, 3)
-        vector.t2_stat_rotated(y_flat, rotation, out_flat)
+        vector.t2_stat_rotated(y_flat, rotation, out_flat, n_dims)
+
     return out
 
 

--- a/eelbrain/_stats/testnd.py
+++ b/eelbrain/_stats/testnd.py
@@ -2332,8 +2332,6 @@ class VectorDifferenceIndependent(Vector):
     def _vector_perm(y, n1, out, seed, use_norm):
         assert use_norm
         n_cases, n_dims, n_tests = y.shape
-        assert n_dims > 1
-        assert n_dims <= 3
         # randomize directions
         rotation = rand_rotation_matrices(n_cases, seed, n_dims)
         # randomize groups

--- a/eelbrain/_stats/testnd.py
+++ b/eelbrain/_stats/testnd.py
@@ -2172,12 +2172,11 @@ class Vector(NDDifferenceTest):
     @staticmethod
     def _vector_perm(y, out, seed, use_norm):
         n_cases, n_dims, n_tests = y.shape
-        assert n_dims == 3
-        rotation = rand_rotation_matrices(n_cases, seed)
+        rotation = rand_rotation_matrices(n_cases, seed, n_dims)
         if use_norm:
-            return vector.mean_norm_rotated(y, rotation, out)
+            return vector.mean_norm_rotated(y, rotation, out, n_dims)
         else:
-            return vector.t2_stat_rotated(y, rotation, out)
+            return vector.t2_stat_rotated(y, rotation, out,  n_dims)
 
     @staticmethod
     def _vector_t2_map(y):
@@ -2333,9 +2332,10 @@ class VectorDifferenceIndependent(Vector):
     def _vector_perm(y, n1, out, seed, use_norm):
         assert use_norm
         n_cases, n_dims, n_tests = y.shape
-        assert n_dims == 3
+        assert n_dims > 1
+        assert n_dims <= 3
         # randomize directions
-        rotation = rand_rotation_matrices(n_cases, seed)
+        rotation = rand_rotation_matrices(n_cases, seed, n_dims)
         # randomize groups
         cases = np.arange(n_cases)
         np.random.shuffle(cases)

--- a/eelbrain/_stats/tests/test_permutation.py
+++ b/eelbrain/_stats/tests/test_permutation.py
@@ -2,10 +2,11 @@
 import sys
 
 import numpy as np
+import pytest
 
 from eelbrain import Factor, Var
 from eelbrain._stats.permutation import (
-    resample, permute_order, permute_sign_flip)
+    resample, permute_order, permute_sign_flip, rand_rotation_matrices)
 
 
 def test_permutation():
@@ -57,3 +58,14 @@ def test_permutation_sign_flip():
     else:
         target = [(-1, 1, -1, -1), (-1, -1, 1, -1), (1, -1, -1, 1)]
     assert list(map(tuple, permute_sign_flip(4, 3))) == target
+
+
+def test_rand_rotation_matrices():
+    seed = 12345
+    with pytest.raises(NotImplementedError):
+        rand_rotation_matrices(10, seed, 4)
+    with pytest.raises(ValueError):
+        rand_rotation_matrices(10, seed, 1)
+    for n in (2, 3):
+        rot_mat = rand_rotation_matrices(10, seed, 2)
+        np.testing.assert_allclose(np.linalg.det(rot_mat), 1)

--- a/eelbrain/_stats/tests/test_stats.py
+++ b/eelbrain/_stats/tests/test_stats.py
@@ -11,7 +11,6 @@ from eelbrain import datasets, Model, Var
 from eelbrain._stats import stats
 from eelbrain._stats.permutation import permute_order, rand_rotation_matrices
 from eelbrain._exceptions import WrongDimensionError
-from eelbrain._utils.r_bridge import r
 
 
 def test_corr():

--- a/eelbrain/_stats/tests/test_stats.py
+++ b/eelbrain/_stats/tests/test_stats.py
@@ -10,6 +10,8 @@ import statsmodels.api as sm
 from eelbrain import datasets, Model, Var
 from eelbrain._stats import stats
 from eelbrain._stats.permutation import permute_order, rand_rotation_matrices
+from eelbrain._exceptions import WrongDimensionError
+from eelbrain._utils.r_bridge import r
 
 
 def test_corr():
@@ -175,8 +177,12 @@ def test_t_ind():
 
 
 def test_vector():
-    # 3D
     ds = datasets.get_uts()
+    # space test should raise error on non-space data
+    with pytest.raises(WrongDimensionError):
+        stats.t2_1samp(ds.eval("uts.x[:,:1]"))
+
+    # 3D
     y = ds.eval("uts.x[:,:3]")
     n_cases = len(y)
     mean = y.mean(axis=0)

--- a/eelbrain/_stats/tests/test_stats.py
+++ b/eelbrain/_stats/tests/test_stats.py
@@ -175,7 +175,40 @@ def test_t_ind():
 
 
 def test_vector():
-    rotation = rand_rotation_matrices(4, 0)
-    zeros = np.zeros((4, 3))
-    assert stats.t2_1samp(zeros) == 0
-    assert stats.t2_1samp(zeros, rotation) == 0
+    # 3D
+    ds = datasets.get_uts()
+    y = ds.eval("uts.x[:,:3]")
+    n_cases = len(y)
+    mean = y.mean(axis=0)
+    sigma = y.T.dot(y) - np.outer(mean, mean) * n_cases
+    sigma /= (n_cases - 1)
+    t2_stat = np.linalg.multi_dot((mean, np.linalg.pinv(sigma), mean))
+    t2_stat *= n_cases
+    np.testing.assert_allclose(stats.t2_1samp(y), t2_stat, atol=1e-7)
+    # rotation
+    rotation = rand_rotation_matrices(n_cases, 0, 3)
+    rotated_y = (rotation * y[:, None, :]).sum(axis=-1)
+    mean = rotated_y.mean(axis=0)
+    sigma = rotated_y.T.dot(rotated_y) - np.outer(mean, mean) * n_cases
+    sigma /= (n_cases - 1)
+    t2_stat = np.linalg.multi_dot((mean, np.linalg.pinv(sigma), mean))
+    t2_stat *= n_cases
+    np.testing.assert_allclose(stats.t2_1samp(y, rotation), t2_stat, atol=1e-7)
+    # 2D
+    y = ds.eval("uts.x[:,:2]")
+    n_cases = len(y)
+    mean = y.mean(axis=0)
+    sigma = y.T.dot(y) - np.outer(mean, mean) * n_cases
+    sigma /= (n_cases - 1)
+    t2_stat = np.linalg.multi_dot((mean, np.linalg.pinv(sigma), mean))
+    t2_stat *= n_cases
+    np.testing.assert_allclose(stats.t2_1samp(y), t2_stat, atol=1e-7)
+    # rotation
+    rotation = rand_rotation_matrices(n_cases, 0, 2)
+    rotated_y = (rotation * y[:, None, :]).sum(axis=-1)
+    mean = rotated_y.mean(axis=0)
+    sigma = rotated_y.T.dot(rotated_y) - np.outer(mean, mean) * n_cases
+    sigma /= (n_cases - 1)
+    t2_stat = np.linalg.multi_dot((mean, np.linalg.pinv(sigma), mean))
+    t2_stat *= n_cases
+    np.testing.assert_allclose(stats.t2_1samp(y, rotation), t2_stat, atol=1e-7)

--- a/eelbrain/_stats/tests/test_testnd.py
+++ b/eelbrain/_stats/tests/test_testnd.py
@@ -9,7 +9,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
 import eelbrain
-from eelbrain import Dataset, NDVar, Categorial, Scalar, UTS, Sensor, configure, datasets, test, testnd, set_log_level, cwt_morlet
+from eelbrain import Dataset, NDVar, Categorial, Scalar, UTS, Sensor, Space, configure, datasets, test, testnd, set_log_level, cwt_morlet
 from eelbrain._exceptions import WrongDimensionError, ZeroVarianceError
 from eelbrain._stats.testnd import Adjacency, NDPermutationDistribution, label_clusters, _MergedTemporalClusterDist, find_peaks, VectorDifferenceIndependent
 from eelbrain._utils.system import IS_WINDOWS
@@ -725,6 +725,36 @@ def test_vector():
     assert 'WARNING' in repr(res)
     res = testnd.Vector(v_small, tfce=0.1, samples=10)
     assert res.p.min() == 0.0
+
+    # 2D case
+    v3d = ds['v3d']
+    space = Space('RA')
+    v2d = NDVar(np.stack((v3d.x[:, 0, :], v3d.x[:, 1, :]), axis=1),
+                (v3d.dims[0], space, v3d.dims[-1]))
+    ds['v2d'] = v2d
+    v1 = ds[30:, 'v3d']
+    v2 = ds[:30, 'v3d']
+    vd = v1 - v2
+    res = testnd.Vector(vd, samples=10)
+    assert res.p.min() == 0
+    difference = res.masked_difference(0.5)
+    # diff related
+    resd = testnd.VectorDifferenceRelated(v1, v2, samples=10)
+    assert_dataobj_equal(resd.p, res.p, name=False)
+    assert_dataobj_equal(resd.t2, res.t2, name=False)
+    # diff independent
+    res = VectorDifferenceIndependent(v1, v2, samples=10, norm=True)
+    assert_dataobj_equal(res.difference, v1.mean('case') - v2.mean('case'), name=False)
+    assert res.p.max() == 1
+    assert res.p.min() == 0
+    # with mp
+    res = testnd.Vector(v1, samples=10)
+    assert res.p.min() == 0.1
+    # without mp
+    configure(n_workers=0)
+    res0 = testnd.Vector(v1, samples=10)
+    assert_array_equal(np.sort(res0._cdist.dist), np.sort(res._cdist.dist))
+    configure(n_workers=True)
 
 
 def test_cwt():

--- a/eelbrain/_stats/vector.py
+++ b/eelbrain/_stats/vector.py
@@ -1,0 +1,22 @@
+# Author: Proloy Das <proloyd94@gmail.com>
+"""
+optimized statistics functions [mostly handles the dispatching]
+
+"""
+from . import vector2d, vector3d
+
+
+def t2_stat(y, out, n_dims=3):
+    dispacher = vector2d if n_dims == 2 else vector3d
+    return dispacher.t2_stat(y, out)
+
+
+def mean_norm_rotated(y, rotation, out, n_dims=3):
+    assert rotation.shape == (y.shape[0], n_dims, n_dims)
+    return vector3d.mean_norm_rotated(y, rotation, out)
+
+
+def t2_stat_rotated(y, rotation, out, n_dims=3):
+    assert rotation.shape == (y.shape[0], n_dims, n_dims)
+    dispacher = vector2d if n_dims == 2 else vector3d
+    return dispacher.t2_stat_rotated(y, rotation, out)

--- a/eelbrain/_stats/vector2d.pyx
+++ b/eelbrain/_stats/vector2d.pyx
@@ -1,0 +1,116 @@
+# Author: Proloy Das <proloyd94@gmail.com>
+# cython: boundscheck=False, wraparound=False, language_level=3
+# distutils: language = c++
+"""
+optimized statistics functions
+
+"""
+cimport cython
+from libc.math cimport sin, cos
+cimport numpy as np
+
+
+@cython.cdivision(True)
+def t2_stat(
+        const np.npy_float64[:,:,:] y,
+        np.npy_float64[:] out,
+):
+    cdef unsigned long i, v, u, case
+    cdef double norm, temp, max_eig, TOL
+
+    cdef double mean[2]
+    cdef double sigma[2][2]
+
+    cdef unsigned long n_cases = y.shape[0]
+    cdef unsigned long n_dims = y.shape[1]
+    cdef unsigned long n_tests = y.shape[2]
+
+    for i in range(n_tests):
+        # Initialization
+        norm = 0
+        for v in range(n_dims):
+            mean[v] = 0.0
+            for u in range(n_dims):
+                sigma[u][v] = 0.0
+        # Computation
+        for case in range(n_cases):
+            for v in range(n_dims):
+                temp = y[case, v, i]
+                mean[v] += temp
+                for u in range(v + 1):
+                    sigma[u][v] += temp * y[case, u, i]
+        for v in range(n_dims):
+            for u in range(v + 1):
+                sigma[u][v] -= mean[u] * mean[v] / n_cases
+                sigma[u][v] /= (n_cases - 1)
+        # check non-zero variance
+        for v in range(n_dims):
+            if sigma[v][v] != 0:
+                break
+        else:
+            out[i] = 0
+            continue
+
+        det_sigma = sigma[0][0] * sigma[1][1] - sigma[0][1]**2
+        norm = mean[0] * mean[0] * sigma[1][1]
+        norm += mean[1] * mean[1] * sigma[0][0]
+        norm -= 2 * mean[0] * mean[1] * sigma[0][1]
+        norm /= det_sigma
+        out[i] = norm / n_cases
+    return out
+
+
+@cython.cdivision(True)
+def t2_stat_rotated(
+        const np.npy_float64[:,:,:] y,
+        const np.npy_float64[:,:,:] rotation,
+        np.npy_float64[:] out,
+):
+    cdef unsigned long i, v, u, case, vi
+    cdef double norm, temp, TOL, max_eig
+
+    cdef double mean[2]
+    cdef double tempv[2]
+    cdef double sigma[2][2]
+
+    cdef unsigned long n_cases = y.shape[0]
+    cdef unsigned long n_dims = y.shape[1]
+    cdef unsigned long n_tests = y.shape[2]
+
+    for i in range(n_tests):
+        # Initialization
+        norm = 0
+        for v in range(n_dims):
+            mean[v] = 0.0
+            for u in range(n_dims):
+                sigma[u][v] = 0.0
+        # Computation
+        for case in range(n_cases):
+            # rotation
+            for u in range(n_dims):
+                tempv[u] = 0
+                for vi in range(n_dims):
+                    tempv[u] += rotation[case, u, vi] * y[case, vi, i]
+                mean[u] += tempv[u]
+                for v in range(u + 1):      # Only upper triangular part is meaningful
+                    sigma[v][u] += tempv[u] * tempv[v]
+        for u in range(n_dims):
+            for v in range(u + 1):      # Only upper triangular part is meaningful
+                sigma[v][u] -= mean[u] * mean[v] / n_cases
+                sigma[v][u] /=  (n_cases - 1)
+        # check non-zero variance
+        for v in range(n_dims):
+            if sigma[v][v] != 0:
+                break
+        else:
+            out[i] = 0
+            continue
+
+        det_sigma = sigma[0][0] * sigma[1][1] - sigma[0][1]**2
+        norm = mean[0] * mean[0] * sigma[1][1]
+        norm += mean[1] * mean[1] * sigma[0][0]
+        norm -= 2 * mean[0] * mean[1] * sigma[0][1]
+        norm /= det_sigma        
+        out[i] = norm / n_cases
+    return out
+

--- a/eelbrain/_stats/vector2d.pyx
+++ b/eelbrain/_stats/vector2d.pyx
@@ -10,6 +10,8 @@ from libc.math cimport sin, cos
 cimport numpy as np
 
 
+cdef double r_TOL = 2.220446049250313e-16
+
 @cython.cdivision(True)
 def t2_stat(
         const np.npy_float64[:,:,:] y,
@@ -55,7 +57,7 @@ def t2_stat(
         norm = mean[0] * mean[0] * sigma[1][1]
         norm += mean[1] * mean[1] * sigma[0][0]
         norm -= 2 * mean[0] * mean[1] * sigma[0][1]
-        norm /= det_sigma
+        norm /= (det_sigma + r_TOL)
         out[i] = norm / n_cases
     return out
 
@@ -110,7 +112,6 @@ def t2_stat_rotated(
         norm = mean[0] * mean[0] * sigma[1][1]
         norm += mean[1] * mean[1] * sigma[0][0]
         norm -= 2 * mean[0] * mean[1] * sigma[0][1]
-        norm /= det_sigma        
+        norm /= (det_sigma + r_TOL)
         out[i] = norm / n_cases
     return out
-

--- a/eelbrain/_stats/vector3d.pyx
+++ b/eelbrain/_stats/vector3d.pyx
@@ -147,7 +147,7 @@ def t2_stat(
         dsyevh3(sigma, vec, eig)
         max_eig = max(eig, 3)
         TOL = r_TOL * max_eig
-        
+
         for v in range(n_dims):
             temp = 0
             for u in range(n_dims):

--- a/eelbrain/_stats/vector3d.pyx
+++ b/eelbrain/_stats/vector3d.pyx
@@ -1,4 +1,4 @@
-# Author: Proloy Das <proloy@umd.edu>
+# Author: Proloy Das <proloyd94@gmail.com>
 # cython: boundscheck=False, wraparound=False, language_level=3
 # distutils: language = c++
 # setuptools: include_dirs = dsyevh3C/
@@ -130,11 +130,12 @@ def t2_stat(
             for v in range(n_dims):
                 temp = y[case, v, i]
                 mean[v] += temp
-                for u in range(n_dims):
+                for u in range(v + 1):
                     sigma[u][v] += temp * y[case, u, i]
         for v in range(n_dims):
-            for u in range(n_dims):
+            for u in range(v + 1):
                 sigma[u][v] -= mean[u] * mean[v] / n_cases
+                sigma[u][v] /= (n_cases-1)
         # check non-zero variance
         for v in range(n_dims):
             if sigma[v][v] != 0:
@@ -146,7 +147,7 @@ def t2_stat(
         dsyevh3(sigma, vec, eig)
         max_eig = max(eig, 3)
         TOL = r_TOL * max_eig
-
+        
         for v in range(n_dims):
             temp = 0
             for u in range(n_dims):
@@ -156,7 +157,7 @@ def t2_stat(
                     norm += temp ** 2 / eig[v]
                 else:
                     norm += temp ** 2 / TOL
-        out[i] = norm ** 0.5
+        out[i] = norm / n_cases
     return out
 
 
@@ -200,6 +201,7 @@ def t2_stat_rotated(
         for u in range(n_dims):
             for v in range(u + 1):      # Only upper triangular part need to be meaningful (See dsyevh.c)
                 sigma[v][u] -= mean[u] * mean[v] / n_cases
+                sigma[v][u] /= (n_cases - 1)
         # check non-zero variance
         for v in range(n_dims):
             if sigma[v][v] != 0:
@@ -221,7 +223,7 @@ def t2_stat_rotated(
                     norm += temp ** 2 / eig[v]
                 else:
                     norm += temp ** 2 / TOL
-        out[i] = norm ** 0.5
+        out[i] = norm / n_cases
     return out
 
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ extensions = [
     Extension('eelbrain._ndvar._gammatone', [f'eelbrain/_ndvar/_gammatone{ext}'], **base_args),
     Extension('eelbrain._stats.adjacency_opt', [f'eelbrain/_stats/adjacency_opt{ext}'], **base_args),
     Extension('eelbrain._stats.opt', [f'eelbrain/_stats/opt{ext}'], **base_args),
-    Extension('eelbrain._stats.vector', [f'eelbrain/_stats/vector{ext_cpp}'], include_dirs=['dsyevh3C'], **base_args),
+    Extension('eelbrain._stats.vector2d', [f'eelbrain/_stats/vector2d{ext_cpp}'], **base_args),
+    Extension('eelbrain._stats.vector3d', [f'eelbrain/_stats/vector3d{ext_cpp}'], include_dirs=['dsyevh3C'], **base_args),
 ]
 if cythonize:
     extensions = cythonize(extensions)


### PR DESCRIPTION
Adds support for 2D Vector field [i.e., complex valued outcomes] in testnd.Vector.

-  Adds `vector2d.pyx` to handle this 2D case.
-  Renames vector.pyx to `vector3d.pyx`.
-  Uses `vector.py` to handle dispatching to appropriate functions.
-  Modifies t2 statistic in `stats` and  `Vector`-xxx tests in `testnd` to conform to the above-mentioned changes.

@christianbrodbeck let me know if the design principle is acceptable or if you have anything else in mind.  