### PR TITLE
Fix repeat

### DIFF
--- a/eelbrain/_data_obj.py
+++ b/eelbrain/_data_obj.py
@@ -5004,7 +5004,7 @@ class NDVar(Named):
         """
         if self.has_case:
             x = self.x.repeat(repeats, axis=0)
-            dims = self.dims
+            dims = ['case', *self.dims[1:]]
         else:
             x = self.x[newaxis].repeat(repeats, axis=0)
             dims = (Case(repeats),) + self.dims

--- a/eelbrain/_ndvar/tests/test_ndvar.py
+++ b/eelbrain/_ndvar/tests/test_ndvar.py
@@ -135,6 +135,7 @@ def test_diff():
     assert_array_equal(diff.x.data, np.diff(y.x, 1, 1, y.x[:, :1]))
     assert_array_equal(diff.x.mask, target_mask)
 
+
 def test_repeat():
     ds = datasets.simulate_erp()
     y = ds['eeg']
@@ -144,6 +145,7 @@ def test_repeat():
     assert len(y_rep.get_dim('case')) == len(y.get_dim('case')) * repeat
     for dim in y_rep.dims[1:]:
         assert len(y_rep.get_dim(dim.name)) == len(y.get_dim(dim.name))
+
 
 def test_dot():
     ds = datasets.get_uts(True)

--- a/eelbrain/_ndvar/tests/test_ndvar.py
+++ b/eelbrain/_ndvar/tests/test_ndvar.py
@@ -135,6 +135,15 @@ def test_diff():
     assert_array_equal(diff.x.data, np.diff(y.x, 1, 1, y.x[:, :1]))
     assert_array_equal(diff.x.mask, target_mask)
 
+def test_repeat():
+    ds = datasets.simulate_erp()
+    y = ds['eeg']
+
+    repeat = 4
+    y_rep = y.repeat(repeat)
+    assert len(y_rep.get_dim('case')) == len(y.get_dim('case')) * repeat
+    for dim in y_rep.dims[1:]:
+        assert len(y_rep.get_dim(dim.name)) == len(y.get_dim(dim.name))
 
 def test_dot():
     ds = datasets.get_uts(True)

--- a/eelbrain/_ndvar/tests/test_ndvar.py
+++ b/eelbrain/_ndvar/tests/test_ndvar.py
@@ -136,17 +136,6 @@ def test_diff():
     assert_array_equal(diff.x.mask, target_mask)
 
 
-def test_repeat():
-    ds = datasets.simulate_erp()
-    y = ds['eeg']
-
-    repeat = 4
-    y_rep = y.repeat(repeat)
-    assert len(y_rep.get_dim('case')) == len(y.get_dim('case')) * repeat
-    for dim in y_rep.dims[1:]:
-        assert len(y_rep.get_dim(dim.name)) == len(y.get_dim(dim.name))
-
-
 def test_dot():
     ds = datasets.get_uts(True)
 

--- a/eelbrain/tests/test_data.py
+++ b/eelbrain/tests/test_data.py
@@ -1569,6 +1569,19 @@ def test_ndvar_timeseries_methods():
     assert x.time.times[0] == 3.2
 
 
+def test_ndvar_methods():
+    "Test other NDVar methods"
+    ds = datasets.simulate_erp()
+    y = ds['eeg']
+
+    # repeat
+    repeat = 4
+    y_rep = y.repeat(repeat)
+    assert len(y_rep.get_dim('case')) == len(y.get_dim('case')) * repeat
+    for dim in y_rep.dims[1:]:
+        assert len(y_rep.get_dim(dim.name)) == len(y.get_dim(dim.name))
+
+
 def test_nested_effects():
     """Test nested effects"""
     ds = datasets.get_uv(nrm=True)


### PR DESCRIPTION
Fixed NDVar.repeat(), previously wouldn't work if NDVar already had 'case' dimension because it tried to make a new NDVar with the old case, which had a mismatch to the # of sides