### PR TITLE
Clean up docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,3 +16,4 @@ conda:
 
 sphinx:
   configuration: doc/conf.py
+  fail_on_warning: true

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -WT --keep-going
 SPHINXBUILD   = sphinx-build
 PAPER         =
 SOURCEDIR     = .

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -13,7 +13,7 @@ Check for open issues, or report new ones on `GitHub <https://github.com/Eelbrai
 
 
 Issues on prior versions
------------
+------------------------
 
 * Fixed in **0.38.3**, Windows only (`#52 <https://github.com/Eelbrain/Eelbrain/issues/52>`_): due to unexpected data loss in :class:`multiprocessing.sharedctypes.RawArray` for large arrays, permutation tests on large datasets using multiprocessing could return spurious results in which *p*-values for *all* clusters were reported as exactly 0.
 
@@ -27,12 +27,12 @@ New in 0.41
 * API:
 
   - To align with MNE-Python, **adjacency** has replaced **connectivity** in the names of:
-  
+
     - Arguments to functions, such as :func:`eelbrain.load.cnd`
     - Function name: ``eelbrain.set_connectivity()`` → :func:`eelbrain.set_adjacency`
     - Method names for all NDVar dimension classes, such as ``eelbrain.Case.connectivity()`` →  :meth:`eelbrain.Case.adjacency`
     - Method names for :class:`Sensor`:
-    
+
       - ``eelbrain.Sensor.get_connectivity()`` →  :meth:`eelbrain.Sensor.get_adjacency`
       - ``eelbrain.Sensor.set_connectivity()`` →  :meth:`eelbrain.Sensor.set_adjacency`
 
@@ -169,7 +169,7 @@ New in 0.32
 * :class:`~pipeline.MneExperiment` pipeline:
 
   - Methods with ``decim`` parameter now also have ``samplingrate`` parameter
-  - More control over :ref:`MneExperiment-events`
+  - More control over :ref:`Pipeline-events`
 
 
 New in 0.31
@@ -363,7 +363,7 @@ New in 0.25
 
   - A new :attr:`pipeline.MneExperiment.sessions` attribute replaces
     ``defaults['experiment']``, with support for multiple sessions in one
-    experiment (see :ref:`MneExperiment-filestructure`).
+    experiment (see :ref:`Pipeline-filestructure`).
   - The :attr:`pipeline.MneExperiment.epochs` parameter ``sel_epoch`` has been removed,
     use ``base`` instead.
   - The setting ``raw='clm'`` has been renamed to ``raw='raw'``.
@@ -389,7 +389,7 @@ New in 0.24
 
 * New test: :class:`test.TTestRelated`.
 * :meth:`pipeline.MneExperiment.make_report_rois` includes corrected p-values in reports
-  for tests in more than one ROI    
+  for tests in more than one ROI
 * :meth:`pipeline.MneExperiment.make_rej` now has a ``decim`` parameter to improve
   display performance.
 * :class:`pipeline.MneExperiment`: BEM-solution files are now created dynamically with
@@ -464,7 +464,7 @@ New in 0.19
 -----------
 
 * Two-stage tests (see :attr:`pipeline.MneExperiment.tests`).
-* Safer cache-handling. See note at :ref:`MneExperiment-intro-analysis`.
+* Safer cache-handling. See note at :ref:`Pipeline-intro-analysis`.
 * :meth:`Dataset.head` and :meth:`Dataset.tail` methods for more efficiently
   inspecting partial Datasets.
 * The default format for plots in reports is now SVG since they are displayed

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,9 +19,7 @@ import sys
 # import eelbrain.plot._brain_object  # make sure that Brain is available
 import eelbrain
 from sphinx_gallery.sorting import _SortKey
-import sphinx.util.logging
 
-logger = sphinx.util.logging.getLogger("eelbrain")
 need_path = str(Path(__file__).parent)
 if need_path not in sys.path:
     sys.path.append(need_path)  # for conf.NameOrder and conf.use_pyplot
@@ -68,6 +66,7 @@ bibtex_bibfiles = ['publications.bib']
 qualname_overrides = {
     "eelbrain._data_obj.NDVar": "eelbrain.NDVar",
 }
+
 
 ################################################################################
 # Sphinx-Gallery

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,8 +14,6 @@ import os
 from pathlib import Path
 import sys
 
-# TODO: This just warns, so doesn't actually make sure Brain is available:
-# import eelbrain.plot._brain_object  # make sure that Brain is available
 import eelbrain
 from sphinx_gallery.sorting import _SortKey
 import eelbrain.datasets._alice

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,19 +78,19 @@ def use_pyplot(gallery_conf, fname):
 
 
 example_order = {
-    'datasets': [
+    '../examples/datasets': [
         'intro.py',
         'dataset-basics.py',
         'align.py',
         'ndvar-creating.py',
         'group-level-analysis.py',
     ],
-    'statistics': [
+    '../examples/statistics': [
         'models.py',
         'RMANOVA.py',
         'ANCOVA.py',
     ],
-    'mass-univariate-statistics': [
+    '../examples/mass-univariate-statistics': [
         'permutation-statistics.py',
         'sensor-ttest.py',
         'sensor-anova.py',
@@ -99,14 +99,14 @@ example_order = {
         'compare-topographies.py',
         'volume-source-space.py',
     ],
-    'plots': [
+    '../examples/plots': [
         'boxplot.py',
         'utsstat.py',
         'colors.py',
         'colormaps.py',
         'customizing.py',
     ],
-    'temporal-response-functions': [
+    '../examples/temporal-response-functions': [
         'trf_intro.py',
         'alice-trf.py',
         'mtrf.py',
@@ -119,19 +119,19 @@ example_order = {
 class NameOrder:
     """Specify sphinx-gallery example order as file tree"""
 
-    items = sum(example_order.values(), [])
-
     def __init__(self, src_dir: str) -> None:
         self.src_dir = src_dir
 
     def __call__(self, item):
-        logger.info(f"NameOrder: {item}")
-        return self.items.index(item)
+        key = str(Path(self.src_dir).relative_to(Path(__file__).parent))
+        idx = example_order[key].index(item)
+        logger.info(f"NameOrder {key} = {idx}: {item}")
+        return idx
 
 
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',   # path to example scripts
-    'subsection_order': [f'../examples/{name}' for name in example_order],
+    'subsection_order': list(example_order),
     'within_subsection_order': "conf.NameOrder",
     'gallery_dirs': 'auto_examples',  # path where to save gallery generated examples
     'filename_pattern': rf'{os.sep}\w',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -123,7 +123,7 @@ class NameOrder:
         self.src_dir = src_dir
 
     def __call__(self, item):
-        key = str(Path(self.src_dir).relative_to(Path(__file__).parent))
+        key = str(Path(self.src_dir).relative_to(Path(__file__).parent).as_posix())
         idx = example_order[key].index(item)
         logger.info(f"NameOrder {key} = {idx}: {item}")
         return idx

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,12 +10,11 @@
 # serve to show the default.
 
 from datetime import datetime
-import os
 from pathlib import Path
+import os
 import sys
 
 import eelbrain
-from sphinx_gallery.sorting import _SortKey
 import eelbrain.datasets._alice
 import mne
 import sphinx.util.logging
@@ -117,10 +116,13 @@ example_order = {
 }
 
 
-class NameOrder(_SortKey):
+class NameOrder:
     """Specify sphinx-gallery example order as file tree"""
 
     items = sum(example_order.values(), [])
+
+    def __init__(self, src_dir: str) -> None:
+        self.src_dir = src_dir
 
     def __call__(self, item):
         logger.info(f"NameOrder: {item}")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,11 +13,18 @@ from datetime import datetime
 from itertools import chain
 import os
 from pathlib import Path
+import sys
 
-import eelbrain.plot._brain_object  # make sure that Brain is available
+# TODO: This just warns, so doesn't actually make sure Brain is available:
+# import eelbrain.plot._brain_object  # make sure that Brain is available
 import eelbrain
-from sphinx_gallery.sorting import ExplicitOrder, _SortKey
+from sphinx_gallery.sorting import _SortKey
+import sphinx.util.logging
 
+logger = sphinx.util.logging.getLogger("eelbrain")
+need_path = str(Path(__file__).parent)
+if need_path not in sys.path:
+    sys.path.append(need_path)  # for conf.NameOrder and conf.use_pyplot
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -61,7 +68,6 @@ bibtex_bibfiles = ['publications.bib']
 qualname_overrides = {
     "eelbrain._data_obj.NDVar": "eelbrain.NDVar",
 }
-
 
 ################################################################################
 # Sphinx-Gallery
@@ -122,15 +128,16 @@ class NameOrder(_SortKey):
 
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',   # path to example scripts
-    'subsection_order': ExplicitOrder([f'../examples/{name}' for name in example_order]),
-    'within_subsection_order': NameOrder,
+    'subsection_order': [f'../examples/{name}' for name in example_order],
+    'within_subsection_order': "conf.NameOrder",
     'gallery_dirs': 'auto_examples',  # path where to save gallery generated examples
     'filename_pattern': rf'{os.sep}\w',
     'default_thumb_file': Path(__file__).parent / 'images' / 'eelbrain.png',
     'min_reported_time': 4,
     'download_all_examples': False,
-    'reset_modules': ('matplotlib', use_pyplot),
+    'reset_modules': ('matplotlib', "conf.use_pyplot"),
     'reference_url': {'eelbrain': None},
+    "backreferences_dir": "generated",
 }
 
 # Disable tqdm (to avoid progress bar output in example gallery)
@@ -230,8 +237,11 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 modindex_common_prefix = ['eelbrain.']
 
-# Supress warnings for badges
-suppress_warnings = ['image.nonlocal_uri']
+# Supress warnings
+suppress_warnings = [
+    'image.nonlocal_uri',  # badges
+    "bibtex.missing_field",  # missing year in some entries
+]
 
 
 # -- Custom Options -----------------------------------------------------------
@@ -265,8 +275,8 @@ html_theme_options = {
     'logo_only': True,
     'includehidden': False,
     'navigation_depth': 2,  # otherwise RTD includes all autosummary sub-headings
-    'html_baseurl': 'https://eelbrain.readthedocs.io/en/stable/',
 }
+html_baseurl = 'https://eelbrain.readthedocs.io/en/stable/'
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -211,6 +211,6 @@ For more on Git we recommend the free `Pro Git book <https://git-scm.com/book>`_
 
 The following tools are used by the maintainers and can streamline development:
 
-- **SourceTree**: A graphical frontend for git (`link <https://www.sourcetreeapp.com>`_).
-- **PyCharm**: A powerful Python IDE that can handle formatting and testing (`link <https://www.jetbrains.com/pycharm>`_).
-- **VS Code**: A lightweight, extensible editor with rich Python tooling support (`link <https://code.visualstudio.com>`_).
+- **SourceTree**: A graphical frontend for git (`link <https://www.sourcetreeapp.com>`__).
+- **PyCharm**: A powerful Python IDE that can handle formatting and testing (`link <https://www.jetbrains.com/pycharm>`__).
+- **VS Code**: A lightweight, extensible editor with rich Python tooling support (`link <https://code.visualstudio.com>`__).

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -90,7 +90,7 @@ The steps below outline the recommended workflow.
 
 1. **Create a Fork** of `Eelbrain <https://github.com/Eelbrain/Eelbrain>`_.
 2. **Create a Branch**: Create a new branch from ``main`` for each feature or fix.
-3. **Commit Changes**: Make your changes and commit them. Individual commit messages are squashed together during merge, therefore it is useful to have good descriptions in the commit messages that apply to the PR as a whole. Less useful commit messages (eg. "fix CI" when CI is not broken before PR) will be removed during merge.
+3. **Commit Changes**: Make your changes and commit them. Individual commit messages are squashed together during merge, therefore it is useful to have good descriptions in the commit messages that apply to the PR as a whole. Less useful commit messages (eg. "fix CI" when CI is not broken before PR) will be removed during merge. 
 4. **Dependency changes**: Any changes to the dependencies should be updated in ``pyproject.toml``, ``env-dev.yml``, ``env-test.yml``, and ``env-readthedocs.yml`` as appropriate.
 5. **Test Locally**:
    Add tests for new features and bug fixes to ensure code quality and prevent regressions.

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -90,7 +90,7 @@ The steps below outline the recommended workflow.
 
 1. **Create a Fork** of `Eelbrain <https://github.com/Eelbrain/Eelbrain>`_.
 2. **Create a Branch**: Create a new branch from ``main`` for each feature or fix.
-3. **Commit Changes**: Make your changes and commit them. Individual commit messages are squashed together during merge, therefore it is useful to have good descriptions in the commit messages that apply to the PR as a whole. Less useful commit messages (eg. "fix CI" when CI is not broken before PR) will be removed during merge. 
+3. **Commit Changes**: Make your changes and commit them. Individual commit messages are squashed together during merge, therefore it is useful to have good descriptions in the commit messages that apply to the PR as a whole. Less useful commit messages (eg. "fix CI" when CI is not broken before PR) will be removed during merge.
 4. **Dependency changes**: Any changes to the dependencies should be updated in ``pyproject.toml``, ``env-dev.yml``, ``env-test.yml``, and ``env-readthedocs.yml`` as appropriate.
 5. **Test Locally**:
    Add tests for new features and bug fixes to ensure code quality and prevent regressions.
@@ -154,7 +154,7 @@ if you get a corresponding error, run ``$ ./fix-bin pytest`` from the
 ``Eelbrain`` repository root.
 
 
-.. _code-style:
+.. _code-style
 
 Coding Style and Documentation
 ------------------------------

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -154,7 +154,7 @@ if you get a corresponding error, run ``$ ./fix-bin pytest`` from the
 ``Eelbrain`` repository root.
 
 
-.. _code-style
+.. _code-style:
 
 Coding Style and Documentation
 ------------------------------

--- a/doc/publications.rst
+++ b/doc/publications.rst
@@ -4,6 +4,5 @@ Publications using Eelbrain
 Ordered by year and alphabetically according to authors' last name:
 
 .. bibliography:: publications.bib
-   :all:
-   :style: year
    :filter: type % "^(?!.*thesis).+$"
+   :style: year

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -529,7 +529,7 @@ More specific control over the plots can be achieved through the
    plot.brain.SequencePlotter
    plot.GlassBrain
 
-See also :meth:`plot.GlassBrain.butterfly`.
+See also :meth:`plot.GlassBrain.butterfly` for a butterfly-plot with a time-linked :class:`~plot.GlassBrain` plot.
 
 In order to make custom plots, a :class:`~plot._brain_object.Brain` figure
 without any data added can be created with

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -528,7 +528,8 @@ More specific control over the plots can be achieved through the
    ~plot._brain_object.Brain
    plot.brain.SequencePlotter
    plot.GlassBrain
-   plot.GlassBrain.butterfly
+
+See also :meth:`plot.GlassBrain.butterfly`.
 
 In order to make custom plots, a :class:`~plot._brain_object.Brain` figure
 without any data added can be created with

--- a/eelbrain/datasets/_alice.py
+++ b/eelbrain/datasets/_alice.py
@@ -1,7 +1,9 @@
 # Helper to download data for Alice example
 from pathlib import Path
+import sys
 
 import pooch
+from tqdm import tqdm
 
 from .._types import PathArg
 
@@ -25,12 +27,29 @@ def get_alice_path(
         registry=registry,
         retry_if_failed=4,
     )
-    # Avoid 403 errors from the server by setting a user agent
-    # adapted from https://github.com/scipy/scipy/pull/22076
-    downloader = pooch.HTTPDownloader(progressbar=progressbar, headers={"User-Agent": "Eelbrain"})
     for fname in registry:
         if (path / fname.split('.')[0]).exists():   # Won't work for multiple eeg.x.zip download
             continue
+        # Avoid 403 errors from the server by setting a user agent
+        # adapted from https://github.com/scipy/scipy/pull/22076
+        progress = SlowTqdm() if progressbar else None
+        downloader = pooch.HTTPDownloader(progressbar=progress, headers={"User-Agent": "Eelbrain"})
         fetcher.fetch(fname, processor=pooch.Unzip(extract_dir='.'), downloader=downloader)
         (path / fname).unlink()
     return path
+
+
+# Adapt base progressbar code:
+# https://github.com/fatiando/pooch/blob/main/pooch/downloaders.py#L238
+# To update more slowly
+class SlowTqdm(tqdm):
+    def __init__(self):
+        use_ascii = bool(sys.platform == "win32")
+        super().__init__(
+            total=1,  # just to make bool() happy
+            mininterval=1.0,  # slower than default 0.1
+            ascii=use_ascii,
+            unit="B",
+            unit_scale=True,
+            leave=True,
+        )

--- a/eelbrain/fmtxt.py
+++ b/eelbrain/fmtxt.py
@@ -1985,6 +1985,7 @@ class Image(FMTextElement, BytesIO):
         """
         return super().seek(pos, whence)
 
+
 class Figure(FMText):
     "Represent a figure with figure caption"
 

--- a/eelbrain/fmtxt.py
+++ b/eelbrain/fmtxt.py
@@ -1969,7 +1969,7 @@ class Image(FMTextElement, BytesIO):
         with open(dst, 'wb') as fid:
             fid.write(buf)
 
-    # Add this to work around a rendering issue
+    # Add this to work around a sphinx rendering issue with the inherited docstring
     def seek(self, pos: int, whence: int = 0, /) -> int:
         """Seek to a position in the buffer.
 

--- a/eelbrain/fmtxt.py
+++ b/eelbrain/fmtxt.py
@@ -1969,6 +1969,21 @@ class Image(FMTextElement, BytesIO):
         with open(dst, 'wb') as fid:
             fid.write(buf)
 
+    # Add this to work around a rendering issue
+    def seek(self, pos: int, whence: int = 0, /) -> int:
+        """Seek to a position in the buffer.
+
+        pos
+            Position to seek to.
+        whence
+            Optional argument that specifies the reference point for pos.
+
+        Returns
+        -------
+        int
+            The new absolute position.
+        """
+        return super().seek(pos, whence)
 
 class Figure(FMText):
     "Represent a figure with figure caption"

--- a/examples/datasets/ndvar-creating.py
+++ b/examples/datasets/ndvar-creating.py
@@ -68,7 +68,7 @@ p = plot.UTS(n400_timecourse)
 
 ###############################################################################
 # Combining NDVars
-# ---------------
+# ----------------
 # More complex NDVars can often be created by combining simpler NDVars.
 # As example data, we generate random values for an independent variable
 # (consistent with simulating an N400 response, we call it "cloze probability")

--- a/examples/mass-univariate-statistics/volume-source-space.py
+++ b/examples/mass-univariate-statistics/volume-source-space.py
@@ -1,5 +1,5 @@
 """
-.. _exa-lm:
+.. _exa-vol:
 
 Volume source space
 ===================


### PR DESCRIPTION
While working on https://github.com/Eelbrain/Eelbrain/pull/133 I noticed several warnings during doc build. That PR fixes a few of them (in files I was already touching), this fixes the rest. I expect it to fail until https://github.com/Eelbrain/Eelbrain/pull/133 lands and I can merge `main` into this branch, though. Hopefully it does, actually, it would indicate the `fail_on_warning: true` RTD config value works correctly!

1. Build with `-WT --keep-going` which means "print errors, treat them as warnings, but don't stop on the first error". This prevents many little linking bugs from popping up during builds.
2. Modernize `sphinx-gallery` conf to allow it to be pickled (this was a warning, and prevents proper build caching for incremental doc updates / builds)
3. Fix the other errors (they are hopefully sufficiently self-explanatory looking at the `diff` but can explain them inline if not)

In many repos I actually build with `-n` as well, which means "nitpicky" where it gets even more particular about finding things like `:py:obj:` link errors and the like. I tried enabling it here but there were way too many warnings, so I'm leaving that as a follow-up for someone if they're motivated.

*EDIT:*

Buliding locally I get:
```
/home/larsoner/python/Eelbrain/doc/development.rst:157: WARNING: malformed hyperlink target. [docutils]
```
and the build fails. Hopefully RTD sees the same...