### PR TITLE
DOC: Add GitHub source links to API documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,6 +43,7 @@ extensions = [
     'sphinx.ext.autodoc', 'sphinx.ext.autosummary',  # default
     'sphinx.ext.todo', 'sphinx.ext.imgmath',  # default
     'sphinx.ext.intersphinx',  # http://sphinx.pocoo.org/ext/intersphinx.html
+    'sphinx.ext.linkcode',  # source links to GitHub
     'sphinx.ext.napoleon',  # https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
     'sphinxcontrib.bibtex',  # https://sphinxcontrib-bibtex.readthedocs.io
     'sphinx_gallery.gen_gallery',  # https://sphinx-gallery.github.io
@@ -67,6 +68,33 @@ bibtex_bibfiles = ['publications.bib']
 qualname_overrides = {
     "eelbrain._data_obj.NDVar": "eelbrain.NDVar",
 }
+
+
+def linkcode_resolve(domain, info):
+    """Resolve source code links to GitHub."""
+    import importlib
+    import inspect
+    if domain != 'py' or not info['module']:
+        return None
+    try:
+        mod = importlib.import_module(info['module'])
+        obj = mod
+        for part in info['fullname'].split('.'):
+            obj = getattr(obj, part)
+        obj = inspect.unwrap(obj)
+        fname = inspect.getfile(obj)
+        source, start = inspect.getsourcelines(obj)
+    except Exception:
+        return None
+    # Make path relative to the repo root
+    repo_root = Path(__file__).parent.parent
+    try:
+        rel = Path(fname).relative_to(repo_root)
+    except ValueError:
+        return None
+    end = start + len(source) - 1
+    tag = f'v{eelbrain.__version__}'
+    return f'https://github.com/christianbrodbeck/Eelbrain/blob/{tag}/{rel.as_posix()}#L{start}-L{end}'
 
 
 ################################################################################

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -93,8 +93,8 @@ def linkcode_resolve(domain, info):
     except ValueError:
         return None
     end = start + len(source) - 1
-    tag = f'v{eelbrain.__version__}'
-    return f'https://github.com/Eelbrain/Eelbrain/blob/{tag}/{rel.as_posix()}#L{start}-L{end}'
+    ref = 'main' if eelbrain.__version__.endswith('.dev') else f'v{eelbrain.__version__}'
+    return f'https://github.com/Eelbrain/Eelbrain/blob/{ref}/{rel.as_posix()}#L{start}-L{end}'
 
 
 ################################################################################

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -86,12 +86,17 @@ def linkcode_resolve(domain, info):
         source, start = inspect.getsourcelines(obj)
     except Exception:
         return None
-    # Make path relative to the repo root
+    # Make path relative to the repo root (works for editable installs);
+    # fall back to site-packages-relative path (e.g. on ReadTheDocs)
     repo_root = Path(__file__).parent.parent
     try:
         rel = Path(fname).relative_to(repo_root)
     except ValueError:
-        return None
+        pkg_root = Path(eelbrain.__file__).parent.parent
+        try:
+            rel = Path(fname).relative_to(pkg_root)
+        except ValueError:
+            return None
     end = start + len(source) - 1
     ref = 'main' if eelbrain.__version__.endswith('.dev') else f'v{eelbrain.__version__}'
     return f'https://github.com/Eelbrain/Eelbrain/blob/{ref}/{rel.as_posix()}#L{start}-L{end}'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,7 +94,7 @@ def linkcode_resolve(domain, info):
         return None
     end = start + len(source) - 1
     tag = f'v{eelbrain.__version__}'
-    return f'https://github.com/christianbrodbeck/Eelbrain/blob/{tag}/{rel.as_posix()}#L{start}-L{end}'
+    return f'https://github.com/Eelbrain/Eelbrain/blob/{tag}/{rel.as_posix()}#L{start}-L{end}'
 
 
 ################################################################################

--- a/doc/static/css/custom.css
+++ b/doc/static/css/custom.css
@@ -116,3 +116,9 @@ div.sphx-glr-script-out div.highlight pre {
     font-size: 13px;
     color: #555555;
 }
+
+/* Source link ([source] button from sphinx.ext.linkcode) */
+.rst-content .viewcode-link {
+    color: #e74c3c;  /* same red as code literals */
+    font-size: 1em;  /* same as signature */
+}


### PR DESCRIPTION
## Summary

- Adds `sphinx.ext.linkcode` to the Sphinx extensions list in `doc/conf.py`
- Defines `linkcode_resolve` to generate GitHub URLs for each documented class/function, pointing to the exact source lines and pinned to the release tag (e.g. `v0.40.0`)
- No new dependencies — `sphinx.ext.linkcode` is bundled with Sphinx

This adds a **[source]** button next to each API entry in the HTML docs that links directly to the corresponding lines on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)