### PR TITLE
Add setuptools_scm version management

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v6.2.0

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
     - if: matrix.os == 'ubuntu-latest'
       name: Install dependencies
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,6 +60,11 @@ jobs:
           name: ${{ matrix.buildplat[1] }}-dist
           path: ./wheelhouse/*.whl
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   test-sdist:
     name: Test sdist
     needs: [build-sdist]

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ doc/auto_examples
 doc/scripts/cache-search.json
 
 test_data/
+wheelhouse/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,6 +11,7 @@
 
 from datetime import datetime
 from pathlib import Path
+from packaging.version import Version
 import os
 import sys
 
@@ -98,7 +99,8 @@ def linkcode_resolve(domain, info):
         except ValueError:
             return None
     end = start + len(source) - 1
-    ref = 'main' if eelbrain.__version__.endswith('.dev') else f'v{eelbrain.__version__}'
+    pkg_version = Version(eelbrain.__version__)
+    ref = 'main' if pkg_version.is_devrelease else f'v{pkg_version.public}'
     return f'https://github.com/Eelbrain/Eelbrain/blob/{ref}/{rel.as_posix()}#L{start}-L{end}'
 
 

--- a/eelbrain/__init__.py
+++ b/eelbrain/__init__.py
@@ -42,5 +42,10 @@ from . import testnd
 
 from .fmtxt import Report
 
+from importlib.metadata import version
 
-__version__ = '0.42.dev'
+try:
+    __version__ = version("eelbrain")
+except Exception:
+    __version__ = "0.0.0"
+del version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 70.1.0",
+    "setuptools_scm >= 6.2",
     "numpy >= 2,< 3",  # build code 2.0 and 1.x compatible
     "cython >= 3",
 ]
@@ -98,7 +99,10 @@ test-requires = [
     "pytest",
     "pingouin",
 ]
-test-command = "pytest -m \"not (slow or framework_build or file_test)\" -rsx -v --pyargs eelbrain"
+test-command = [
+  "python -c \"import eelbrain; v = eelbrain.__version__; assert v != '0.0.0' and v[0].isdigit(), f'Bad version: {v!r}'\"",
+  "pytest -m \"not (slow or framework_build or file_test)\" -rsx -v --pyargs eelbrain",
+]
 
 [tool.cibuildwheel.linux]
 repair-wheel-command = [
@@ -151,5 +155,4 @@ include-package-data = false
 [tool.setuptools.packages.find]
 include = ['eelbrain*']
 
-[tool.setuptools.dynamic]
-version = {attr = "eelbrain.__version__"}
+[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ repair-wheel-command = [
 select = "*-musllinux*"
 test-requires = [
     "pytest",
+    "pytest-cov",
     "statsmodels",  # no pingouin because it requires sklearn, which does not have binary wheels
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,11 +97,12 @@ archs = ["native"]
 before-build = "pip install abi3audit"
 test-requires = [
     "pytest",
+    "pytest-cov",
     "pingouin",
 ]
 test-command = [
   "python -c \"import eelbrain; v = eelbrain.__version__; assert v != '0.0.0' and v[0].isdigit(), f'Bad version: {v!r}'\"",
-  "pytest -m \"not (slow or framework_build or file_test)\" -rsx -v --pyargs eelbrain",
+  "pytest -m \"not (slow or framework_build or file_test)\" -rsx -v --pyargs eelbrain --cov eelbrain --cov-report=xml:{project}/coverage.xml",
 ]
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
Closes #193

Locally I get:
```
>>> eelbrain.__version__
'0.42.dev51+g97c3f11d9.d20260630'
```
This format is configurable in the config, but the default seems pretty useful (number of commits past last release, plus hash, plus date it was built).