### PR TITLE
Fix: set name on Datalist returned by _load_predictor_nested

### DIFF
--- a/eelbrain/_experiment/trf/nodes.py
+++ b/eelbrain/_experiment/trf/nodes.py
@@ -394,7 +394,9 @@ class TRFDerivative(Derivative[object]):
             x = filter_predictor(x, self.raw, ctx.state['raw'], filter_x)
             x.name = term.string
             xs.append(x)
-        return Datalist(xs)
+        result = Datalist(xs)
+        result.name = term.string
+        return result
 
     def _load_subject_predictor(self, ctx: Request, predictor: SubjectUTSPredictor, term: Term, ds, y, filter_x: bool | str, is_nested: bool) -> NDVar | Datalist:
         "Cut recording-long predictors into response cases"

--- a/eelbrain/_experiment/trf/nodes.py
+++ b/eelbrain/_experiment/trf/nodes.py
@@ -394,9 +394,7 @@ class TRFDerivative(Derivative[object]):
             x = filter_predictor(x, self.raw, ctx.state['raw'], filter_x)
             x.name = term.string
             xs.append(x)
-        result = Datalist(xs)
-        result.name = term.string
-        return result
+        return Datalist(xs, name=term.string)
 
     def _load_subject_predictor(self, ctx: Request, predictor: SubjectUTSPredictor, term: Term, ds, y, filter_x: bool | str, is_nested: bool) -> NDVar | Datalist:
         "Cut recording-long predictors into response cases"


### PR DESCRIPTION
_load_predictor_nested() names each individual item inside the returned Datalist (x.name = term.string), but never names the Datalist container itself. 
Boosting._fit() checks .name on each item in xs to detect duplicate predictor names. For ContinuousEpoch models, each item in xs is actually a Datalist (a container holding multiple named predictors) rather than a single named predictor, and the container itself was never given a name, so this check reads None for every term, causing this error for any multi-term model on a ContinuousEpoch:

    TypeError: sequence item 0: expected str instance, NoneType found


Fix: give the returned Datalist the same name as its contents.

    result = Datalist(xs)
    result.name = term.string
    return result

Tested on a two-term model that was previously crashing, now fits successfully with both predictor names showing correctly.