### PR TITLE
Pipeline: add by-predictor TRF lags

### DIFF
--- a/eelbrain/_experiment/derivative_cache/base.py
+++ b/eelbrain/_experiment/derivative_cache/base.py
@@ -320,9 +320,10 @@ class OptionSpec:
     normalize
         Called as ``normalize(value)`` before validation; the return
         value replaces the option value for the whole request (key,
-        fingerprint, and build all see the normalized value). Must be
-        idempotent, since child requests are normalized again when they are
-        resolved.
+        fingerprint, and build all see the normalized value). Runs for every
+        non-default value, including values that already have ``type``, so it
+        can canonicalize typed values. Must be idempotent, since child
+        requests are normalized again when they are resolved.
     """
 
     default: Any
@@ -334,12 +335,12 @@ class OptionSpec:
         """Normalize and validate one option value for ``ctx``."""
         if value is None and self.default is None:
             return value
-        elif self.type and isinstance(value, self.type):
-            return value
         elif self.normalize:
             value = self.normalize(value)
             if self.type:
                 assert isinstance(value, self.type)
+            return value
+        elif self.type and isinstance(value, self.type):
             return value
         elif self.type:
             if not isinstance(self.type, tuple):

--- a/eelbrain/_experiment/derivative_cache/base.py
+++ b/eelbrain/_experiment/derivative_cache/base.py
@@ -578,14 +578,19 @@ class DependencyNode(Generic[T]):
         return {*cls.key_options, *cls.view_options}
 
     def validate_options(self, ctx: Request) -> None:
-        """Reject invalid combinations of option values.
+        """Normalize and reject invalid combinations of option values.
 
         Called exactly once per request, after :class:`OptionSpec` normalization
         and before the cache key is computed, so an invalid combination can fail
-        before any expensive work.
+        before any expensive work. Combinations that are canonical only in
+        combination may be normalized by updating ``ctx.options`` in place, so
+        equivalent spellings share one canonical key; such normalization must be
+        idempotent, since child requests are normalized again when they are
+        resolved.
 
-        Override this for constraints spanning several options, or options and state
-        (validate individual options in :class:`OptionSpec`).
+        Override this for constraints or canonicalization spanning several
+        options, or options and state (handle individual options in
+        :class:`OptionSpec`).
         """
 
     def override_key_fields(self, ctx: Request) -> tuple[str, ...] | None:

--- a/eelbrain/_experiment/derivative_cache/tests/test_derivative_cache.py
+++ b/eelbrain/_experiment/derivative_cache/tests/test_derivative_cache.py
@@ -1255,6 +1255,12 @@ def test_option_spec_normalize_canonicalizes_cache_key():
     assert derivative.build_calls == 1
 
 
+def test_option_spec_normalize_runs_for_typed_values():
+    # normalize canonicalizes even values that already have the declared type (e.g. a Term object carrying lag windows a predictor request must strip)
+    spec = OptionSpec('', type=str, normalize=str.lower)
+    assert spec.validated(None, 'label', 'ABC') == 'abc'
+
+
 def test_override_key_options_narrows_key():
     root, registry = make_empty_registry()
     registry.register(NarrowingDerivative(root))

--- a/eelbrain/_experiment/pipeline.py
+++ b/eelbrain/_experiment/pipeline.py
@@ -1500,7 +1500,11 @@ class Pipeline(StateModel):
         x
             Model comparison, such as ``'acoustic + lexical > acoustic'`` or
             ``'acoustic + lexical @ lexical'``. Comparisons against ``0`` test
-            one model's predictive power against zero.
+            one model's predictive power against zero. A term can override the
+            lag window with slice syntax, e.g.
+            ``'acoustic + lexical @ lexical[0.2:]'`` tests the contribution of
+            ``lexical`` at lags from 0.2 s to ``tstop`` (an omitted boundary
+            uses ``tstart``/``tstop``).
         tstart
             Start of the TRF in seconds.
         tstop

--- a/eelbrain/_experiment/pipeline.py
+++ b/eelbrain/_experiment/pipeline.py
@@ -1286,8 +1286,16 @@ class Pipeline(StateModel):
             data_string = 'sensor'
         else:
             data_string = self._resolve_data(data).string
-        x_ = self._eval_trf_x(x, comparison).sorted()
-        return {'x': x_, 'tstart': float(tstart), 'tstop': float(tstop), 'estimator': estimator, 'data': data_string, 'samplingrate': samplingrate, 'filter_x': filter_x}
+        tstart = float(tstart)
+        tstop = float(tstop)
+        x_ = self._eval_trf_x(x, comparison).resolve_lags(tstart, tstop).sorted()
+        # A model-wide bound enters the fit only where a term leaves it open; normalize unused bounds to None so they do not affect the cache key
+        models = x_.models if isinstance(x_, Comparison) else (x_,)
+        if all(term.tstart is not None for model in models for term in model.terms):
+            tstart = None
+        if all(term.tstop is not None for model in models for term in model.terms):
+            tstop = None
+        return {'x': x_, 'tstart': tstart, 'tstop': tstop, 'estimator': estimator, 'data': data_string, 'samplingrate': samplingrate, 'filter_x': filter_x}
 
     def load_trf(
             self,

--- a/eelbrain/_experiment/pipeline.py
+++ b/eelbrain/_experiment/pipeline.py
@@ -1244,7 +1244,7 @@ class Pipeline(StateModel):
             State parameters.
         """
         self.set(**state)
-        term = parse_term(code)
+        term = parse_term(code).without_lags()  # lag overrides do not affect the predictor itself
         predictor = self.predictors[term.predictor_key]
         if not isinstance(predictor, (UTSPredictor, NUTSPredictor)):
             raise NotImplementedError(f"{term.string}: load_predictor only supports file predictors; load {type(predictor).__name__} through load_trf")
@@ -1307,7 +1307,9 @@ class Pipeline(StateModel):
         Parameters
         ----------
         x
-            Model (e.g. ``'gammatone + word'``).
+            Model (e.g. ``'gammatone + word'``). A term can override the lag
+            window with slice syntax, e.g. ``'gammatone[0.2:] + word[-0.1:0.8]'``
+            (an omitted boundary uses ``tstart``/``tstop``).
         tstart
             Start of the TRF in seconds.
         tstop
@@ -1379,7 +1381,9 @@ class Pipeline(StateModel):
         Parameters
         ----------
         x
-            Model (e.g. ``'gammatone + word'``).
+            Model (e.g. ``'gammatone + word'``). A term can override the lag
+            window with slice syntax, e.g. ``'gammatone[0.2:] + word[-0.1:0.8]'``
+            (an omitted boundary uses ``tstart``/``tstop``).
         tstart
             Start of the TRF in seconds.
         tstop
@@ -1428,7 +1432,9 @@ class Pipeline(StateModel):
             group name such as ``'all'``. ``1`` to use the current subject;
             ``-1`` for the current group.
         x
-            Model (e.g. ``'gammatone + word'``).
+            Model (e.g. ``'gammatone + word'``). A term can override the lag
+            window with slice syntax, e.g. ``'gammatone[0.2:] + word[-0.1:0.8]'``
+            (an omitted boundary uses ``tstart``/``tstop``).
         tstart
             Start of the TRF in seconds.
         tstop

--- a/eelbrain/_experiment/pipeline.py
+++ b/eelbrain/_experiment/pipeline.py
@@ -434,7 +434,7 @@ class Pipeline(StateModel):
         # TRF: named models, estimators, predictors, stimulus variables
         self._named_models: dict[str, Model] = ConfigurationDict('model')
         for name, value in self.models.items():
-            self._named_models[name] = Model.coerce(value).initialize(self._named_models)
+            self._named_models[name] = Model.coerce(value, self._named_models)
         estimators = {'boosting': Boosting(), **self.estimators}
         for name, estimator in estimators.items():
             if not isinstance(estimator, Estimator):
@@ -1286,16 +1286,8 @@ class Pipeline(StateModel):
             data_string = 'sensor'
         else:
             data_string = self._resolve_data(data).string
-        tstart = float(tstart)
-        tstop = float(tstop)
-        x_ = self._eval_trf_x(x, comparison).resolve_lags(tstart, tstop).sorted()
-        # A model-wide bound enters the fit only where a term leaves it open; normalize unused bounds to None so they do not affect the cache key
-        models = x_.models if isinstance(x_, Comparison) else (x_,)
-        if all(term.tstart is not None for model in models for term in model.terms):
-            tstart = None
-        if all(term.tstop is not None for model in models for term in model.terms):
-            tstop = None
-        return {'x': x_, 'tstart': tstart, 'tstop': tstop, 'estimator': estimator, 'data': data_string, 'samplingrate': samplingrate, 'filter_x': filter_x}
+        x_ = self._eval_trf_x(x, comparison)
+        return {'x': x_, 'tstart': float(tstart), 'tstop': float(tstop), 'estimator': estimator, 'data': data_string, 'samplingrate': samplingrate, 'filter_x': filter_x}
 
     def load_trf(
             self,
@@ -3286,7 +3278,7 @@ class Pipeline(StateModel):
         if any(operator in x for operator in ('@', '=', '<', '>')):
             out = Comparison.coerce(x, self._named_models)
         else:
-            out = Model.coerce(x).initialize(self._named_models)
+            out = Model.coerce(x, self._named_models)
         if comparison and not isinstance(out, Comparison):
             raise TypeError(f"{x=}: need a model comparison, such as 'a + b > a'")
         elif comparison is False and isinstance(out, Comparison):

--- a/eelbrain/_experiment/tests/test_sample_experiment.py
+++ b/eelbrain/_experiment/tests/test_sample_experiment.py
@@ -2102,6 +2102,50 @@ def test_load_trf(samples_experiment):
 
 
 @requires_mne_sample_data
+def test_load_trf_term_lags(samples_experiment):
+    "Per-term lag windows through model-string slice syntax"
+    from eelbrain import BoostingResult
+    from eelbrain._experiment.tests.sample_experiment import SampleTRF
+
+    set_log_level('warning', 'mne')
+    root = samples_experiment(n_subjects=1, n_segments=4)
+    e = SampleTRF(root)
+    e.set(subject='R0000', epoch='target', epoch_rejection='', raw='1-40', inv='')
+    tstep = e.load_epochs(reject=False)['mag'].time.tstep
+    samplingrate = 1 / tstep
+
+    # UTS predictor files
+    pdir = Path(root) / 'derivatives' / 'predictors'
+    pdir.mkdir(parents=True, exist_ok=True)
+    rng = np.random.RandomState(0)
+    for stim in ('auditory', 'visual'):
+        x = NDVar(rng.normal(0, 1, 100), UTS(0, tstep, 100), name='env')
+        save.pickle(x, pdir / f'{stim}~env.pickle')
+
+    # per-term override alongside the model-wide window (terms are fit in sorted order)
+    res = e.load_trf('imp + env[0.02:0.08]', 0, 0.1, samplingrate=samplingrate)
+    assert isinstance(res, BoostingResult)
+    assert res.tstart == (0.02, 0)
+    assert res.tstop == (0.08, 0.1)
+
+    # the same predictor with two lag windows shares one predictor-file dependency
+    res = e.load_trf('env[:0.05] + env[0.02:]', 0, 0.1, samplingrate=samplingrate)
+    assert res.tstart == (0.02, 0)
+    assert res.tstop == (0.1, 0.05)
+    options = e._trf_options('env[:0.05] + env[0.02:]', 0., 0.1, 'boosting', None, samplingrate, False, {})
+    ctx = e._resolve_derivative('trf', options=options)
+    assert ctx.is_valid()
+    dependencies = ctx._manifest().dependencies
+    assert 'auditory~env' in dependencies
+    assert not any('[' in key for key in dependencies)
+
+    # single-term model: scalar lags for the single x
+    res = e.load_trf('env[0.02:0.08]', 0, 0.1, samplingrate=samplingrate)
+    assert res.tstart == 0.02
+    assert res.tstop == 0.08
+
+
+@requires_mne_sample_data
 def test_predictor_subset_fingerprint(samples_experiment):
     "Editing an unused predictor-file column does not invalidate a cached TRF; editing a used one does"
     import os

--- a/eelbrain/_experiment/tests/test_sample_experiment.py
+++ b/eelbrain/_experiment/tests/test_sample_experiment.py
@@ -2175,10 +2175,10 @@ def test_load_trf_term_lags(samples_trf_experiment):
     assert res.tstop == (0.08, 0.1)
 
     # the same predictor with two lag windows shares one predictor-file dependency
-    res = e.load_trf('env[:0.05] + env[0.02:]', 0, 0.1)
-    assert res.tstart == (0.02, 0)
+    res = e.load_trf('env[:0.05] + env[0.05:]', 0, 0.1)
+    assert res.tstart == (0.05, 0)
     assert res.tstop == (0.1, 0.05)
-    options = e._trf_options('env[:0.05] + env[0.02:]', 0., 0.1, 'boosting', None, None, False, {})
+    options = e._trf_options('env[:0.05] + env[0.05:]', 0., 0.1, 'boosting', None, None, False, {})
     ctx = e._resolve_derivative('trf', options=options)
     assert ctx.is_valid()
     dependencies = ctx._manifest().dependencies
@@ -2189,6 +2189,11 @@ def test_load_trf_term_lags(samples_trf_experiment):
     res = e.load_trf('env[0.02:0.08]', 0, 0.1)
     assert res.tstart == 0.02
     assert res.tstop == 0.08
+
+    # comparison omitting a lag window resolves to the complement
+    comparison = e._eval_trf_x('imp + env @ env[:0.05]')
+    assert comparison.x1.name == 'imp + env'
+    assert comparison.x0.name == 'imp + env[0.05:]'
 
 
 @requires_mne_sample_data

--- a/eelbrain/_experiment/tests/test_sample_experiment.py
+++ b/eelbrain/_experiment/tests/test_sample_experiment.py
@@ -73,6 +73,26 @@ def _samples_templates(tmp_path_factory):
     return tmp_path_factory.mktemp('samples_templates'), {}
 
 
+def _samples_template(
+        template_dir: Path,
+        cache: dict,
+        n_subjects: int = 3,
+        n_tasks: int = 1,
+        n_segments: int = 4,
+        n_runs: int = 1,
+        mris: bool = False,
+        pick: str = 'mag',
+) -> Path:
+    "Session-cached bare dataset template for one setup configuration"
+    key = (n_subjects, n_tasks, n_segments, n_runs, mris, pick)
+    if key not in cache:
+        template = template_dir / f'template-{len(cache)}'
+        template.mkdir()
+        datasets.setup_samples_experiment(template, n_subjects, n_tasks, n_segments, n_runs, mris, pick=pick)
+        cache[key] = template / 'SampleExperiment'
+    return cache[key]
+
+
 @pytest.fixture
 def samples_experiment(_samples_templates, tmp_path):
     """Sample-experiment dataset roots backed by per-configuration templates.
@@ -95,15 +115,59 @@ def samples_experiment(_samples_templates, tmp_path):
     ) -> str:
         if not mne.datasets.has_dataset("sample"):
             pytest.skip("mne sample data unavailable")
-        key = (n_subjects, n_tasks, n_segments, n_runs, mris, pick)
-        if key not in cache:
-            template = template_dir / f'template-{len(cache)}'
-            template.mkdir()
-            datasets.setup_samples_experiment(template, n_subjects, n_tasks, n_segments, n_runs, mris, pick=pick)
-            cache[key] = template / 'SampleExperiment'
+        template = _samples_template(template_dir, cache, n_subjects, n_tasks, n_segments, n_runs, mris, pick)
         root = tmp_path / f'experiment-{next(counter)}' / 'SampleExperiment'
-        shutil.copytree(cache[key], root)
+        shutil.copytree(template, root)
         return str(root)
+
+    return make
+
+
+@pytest.fixture
+def samples_trf_experiment(_samples_templates, tmp_path):
+    """Configured :class:`SampleTRF` experiments backed by a warmed session template.
+
+    Like ``samples_experiment(n_subjects=1, n_segments=4)``, but the
+    session-cached template additionally contains the ``{stim}~env.pickle``
+    UTS predictor files (one 60-sample random time series per ``modality``
+    stimulus, at the epochs' native tstep) and the derived raw/epoch artifacts
+    for the standard TRF test state (subject R0000, epoch 'target', raw
+    '1-40', no rejection, sensor space). The derivative cache is root-relative
+    and ``copytree`` preserves mtimes, so each test's copy starts with cache
+    hits for everything but what the test itself adds (e.g. the fit). Every
+    call returns a fresh :class:`SampleTRF` instance, already set to the
+    standard state, on its own copy of the template.
+    """
+    from eelbrain._experiment.tests.sample_experiment import SampleTRF
+
+    template_dir, cache = _samples_templates
+    counter = itertools.count()
+    state = {'subject': 'R0000', 'epoch': 'target', 'epoch_rejection': '', 'raw': '1-40', 'inv': ''}
+
+    def make():
+        if not mne.datasets.has_dataset("sample"):
+            pytest.skip("mne sample data unavailable")
+        set_log_level('warning', 'mne')
+        if 'trf' not in cache:
+            base = _samples_template(template_dir, cache, n_subjects=1)
+            template = template_dir / f'template-{len(cache)}' / 'SampleExperiment'
+            shutil.copytree(base, template)
+            e = SampleTRF(template)
+            e.set(**state)
+            # warm the raw/epoch derivatives; the native (decimated) tstep is an
+            # integer ratio of the raw rate, so predictors at this tstep need no resampling
+            tstep = e.load_epochs(reject=False)['mag'].time.tstep
+            pdir = template / 'derivatives' / 'predictors'
+            pdir.mkdir(parents=True, exist_ok=True)
+            rng = np.random.RandomState(0)
+            for stim in ('auditory', 'visual'):
+                save.pickle(NDVar(rng.normal(size=60), UTS(0, tstep, 60), name='env'), pdir / f'{stim}~env.pickle')
+            cache['trf'] = template
+        root = tmp_path / f'experiment-{next(counter)}' / 'SampleExperiment'
+        shutil.copytree(cache['trf'], root)
+        e = SampleTRF(root)
+        e.set(**state)
+        return e
 
     return make
 
@@ -2053,16 +2117,12 @@ def test_sample_eeg(samples_experiment):
 
 
 @requires_mne_sample_data
-def test_load_trf(samples_experiment):
+def test_load_trf(samples_trf_experiment):
     "load_trf, caching, and the separable TRFJob"
     import pickle
     from eelbrain import BoostingResult
-    from eelbrain._experiment.tests.sample_experiment import SampleTRF
 
-    set_log_level('warning', 'mne')
-    root = samples_experiment(n_subjects=1, n_segments=4)
-    e = SampleTRF(root)
-    e.set(subject='R0000', epoch='target', epoch_rejection='', raw='1-40', inv='')
+    e = samples_trf_experiment()
 
     # compute
     res = e.load_trf('imp', 0, 0.1)
@@ -2102,37 +2162,23 @@ def test_load_trf(samples_experiment):
 
 
 @requires_mne_sample_data
-def test_load_trf_term_lags(samples_experiment):
+def test_load_trf_term_lags(samples_trf_experiment):
     "Per-term lag windows through model-string slice syntax"
     from eelbrain import BoostingResult
-    from eelbrain._experiment.tests.sample_experiment import SampleTRF
 
-    set_log_level('warning', 'mne')
-    root = samples_experiment(n_subjects=1, n_segments=4)
-    e = SampleTRF(root)
-    e.set(subject='R0000', epoch='target', epoch_rejection='', raw='1-40', inv='')
-    tstep = e.load_epochs(reject=False)['mag'].time.tstep
-    samplingrate = 1 / tstep
-
-    # UTS predictor files
-    pdir = Path(root) / 'derivatives' / 'predictors'
-    pdir.mkdir(parents=True, exist_ok=True)
-    rng = np.random.RandomState(0)
-    for stim in ('auditory', 'visual'):
-        x = NDVar(rng.normal(0, 1, 100), UTS(0, tstep, 100), name='env')
-        save.pickle(x, pdir / f'{stim}~env.pickle')
+    e = samples_trf_experiment()
 
     # per-term override alongside the model-wide window (terms are fit in sorted order)
-    res = e.load_trf('imp + env[0.02:0.08]', 0, 0.1, samplingrate=samplingrate)
+    res = e.load_trf('imp + env[0.02:0.08]', 0, 0.1)
     assert isinstance(res, BoostingResult)
     assert res.tstart == (0.02, 0)
     assert res.tstop == (0.08, 0.1)
 
     # the same predictor with two lag windows shares one predictor-file dependency
-    res = e.load_trf('env[:0.05] + env[0.02:]', 0, 0.1, samplingrate=samplingrate)
+    res = e.load_trf('env[:0.05] + env[0.02:]', 0, 0.1)
     assert res.tstart == (0.02, 0)
     assert res.tstop == (0.1, 0.05)
-    options = e._trf_options('env[:0.05] + env[0.02:]', 0., 0.1, 'boosting', None, samplingrate, False, {})
+    options = e._trf_options('env[:0.05] + env[0.02:]', 0., 0.1, 'boosting', None, None, False, {})
     ctx = e._resolve_derivative('trf', options=options)
     assert ctx.is_valid()
     dependencies = ctx._manifest().dependencies
@@ -2140,27 +2186,22 @@ def test_load_trf_term_lags(samples_experiment):
     assert not any('[' in key for key in dependencies)
 
     # single-term model: scalar lags for the single x
-    res = e.load_trf('env[0.02:0.08]', 0, 0.1, samplingrate=samplingrate)
+    res = e.load_trf('env[0.02:0.08]', 0, 0.1)
     assert res.tstart == 0.02
     assert res.tstop == 0.08
 
 
 @requires_mne_sample_data
-def test_predictor_subset_fingerprint(samples_experiment):
+def test_predictor_subset_fingerprint(samples_trf_experiment):
     "Editing an unused predictor-file column does not invalidate a cached TRF; editing a used one does"
     import os
     from eelbrain import BoostingResult, Dataset, Var, save
-    from eelbrain._experiment.tests.sample_experiment import SampleTRF
 
-    set_log_level('warning', 'mne')
-    root = samples_experiment(n_subjects=1, n_segments=4)
-    e = SampleTRF(root)
-    e.set(subject='R0000', epoch='target', epoch_rejection='', raw='1-40', inv='')
+    e = samples_trf_experiment()
     samplingrate = 1 / e.load_epochs(reject=False)['mag'].time.tstep
 
-    pdir = Path(root) / 'derivatives' / 'predictors'
-    pdir.mkdir(parents=True, exist_ok=True)
-    ref_dir = Path(root) / 'derivatives' / 'eelbrain' / 'cache' / 'predictor'
+    pdir = e.root / 'derivatives' / 'predictors'
+    ref_dir = e.root / 'derivatives' / 'eelbrain' / 'cache' / 'predictor'
     mtime = [1_700_000_000]
 
     def write(stim, value, unused):
@@ -2238,29 +2279,16 @@ def test_load_trf_source(samples_experiment):
 
 
 @requires_mne_sample_data
-def test_load_trf_filepredictor(samples_experiment):
+def test_load_trf_filepredictor(samples_trf_experiment):
     "load_trf with a UTSPredictor: per-stimulus predictor dependency edges"
-    from eelbrain import BoostingResult, NDVar, UTS, save
-    from eelbrain._experiment.tests.sample_experiment import SampleTRF
+    from eelbrain import BoostingResult, NDVar, save
 
-    set_log_level('warning', 'mne')
-    root = samples_experiment(n_subjects=1, n_segments=4)
-    e = SampleTRF(root)
-    e.set(subject='R0000', epoch='target', epoch_rejection='', raw='1-40', inv='')
-
-    # match the predictor sampling to the data's natural (decimated) rate so the
-    # samplingrate is an integer ratio of the raw rate and needs no resampling
+    # the fixture provides a predictor file per stimulus (one for each 'modality' cell)
+    e = samples_trf_experiment()
     tstep = e.load_epochs(reject=False)['mag'].time.tstep
     samplingrate = 1 / tstep
-
-    # write a predictor file per stimulus (one for each 'modality' cell)
-    pdir = Path(root) / 'derivatives' / 'predictors'
-    pdir.mkdir(parents=True, exist_ok=True)
-    uts = UTS(0, tstep, 60)
-    rng = np.random.RandomState(0)
-    predictor_ndvars = {stim: NDVar(rng.normal(size=60), uts, name='env') for stim in ('auditory', 'visual')}
-    for stim, ndvar in predictor_ndvars.items():
-        save.pickle(ndvar, pdir / f'{stim}~env.pickle')
+    pdir = e.root / 'derivatives' / 'predictors'
+    predictor_ndvars = {stim: load.unpickle(pdir / f'{stim}~env.pickle') for stim in ('auditory', 'visual')}
 
     # load_predictor shapes one stimulus' file into an NDVar at the requested tstep
     x = e.load_predictor('auditory~env', tstep)
@@ -2292,7 +2320,9 @@ def test_load_trf_filepredictor(samples_experiment):
     assert e._resolve_derivative('trf', options=options).is_valid()
 
     # editing a predictor file invalidates the cached TRF
-    save.pickle(NDVar(rng.normal(size=60), uts, name='env'), pdir / 'auditory~env.pickle')
+    edited = predictor_ndvars['auditory'] + 1
+    edited.name = 'env'
+    save.pickle(edited, pdir / 'auditory~env.pickle')
     assert not e._resolve_derivative('trf', options=options).is_valid()
 
 

--- a/eelbrain/_experiment/tests/test_sample_experiment.py
+++ b/eelbrain/_experiment/tests/test_sample_experiment.py
@@ -2165,6 +2165,7 @@ def test_load_trf(samples_trf_experiment):
 def test_load_trf_term_lags(samples_trf_experiment):
     "Per-term lag windows through model-string slice syntax"
     from eelbrain import BoostingResult
+    from eelbrain._experiment.trf.model import TRFModelError
 
     e = samples_trf_experiment()
 
@@ -2173,11 +2174,13 @@ def test_load_trf_term_lags(samples_trf_experiment):
     assert isinstance(res, BoostingResult)
     assert res.tstart == (0.02, 0)
     assert res.tstop == (0.08, 0.1)
+    assert [h.name for h in res.h] == ['env', 'imp']  # a unique predictor is named without its lag window
 
     # the same predictor with two lag windows shares one predictor-file dependency
     res = e.load_trf('env[:0.05] + env[0.05:]', 0, 0.1)
     assert res.tstart == (0.05, 0)
     assert res.tstop == (0.1, 0.05)
+    assert [h.name for h in res.h] == ['env[0.05:]', 'env[:0.05]']  # lag windows disambiguate a split predictor
     options = e._trf_options('env[:0.05] + env[0.05:]', 0., 0.1, 'boosting', None, None, False, {})
     ctx = e._resolve_derivative('trf', options=options)
     assert ctx.is_valid()
@@ -2190,10 +2193,24 @@ def test_load_trf_term_lags(samples_trf_experiment):
     assert res.tstart == 0.02
     assert res.tstop == 0.08
 
+    # all terms with complete windows: the unused model-wide bounds are normalized out of the cache key
+    options = e._trf_options('env[0.02:0.08]', 0., 0.1, 'boosting', None, None, False, {})
+    assert options['tstart'] is None
+    assert options['tstop'] is None
+    assert e.load_trf('env[0.02:0.08]', 0, 0.5, path_only=True) == e.load_trf('env[0.02:0.08]', 0, 0.1, path_only=True)
+    # a partially specified model keeps the bound a term still uses
+    options = e._trf_options('imp[0:] + env[0.02:]', 0., 0.1, 'boosting', None, None, False, {})
+    assert options['tstart'] is None
+    assert options['tstop'] == 0.1
+    with pytest.raises(TRFModelError):  # resolved window of env is empty
+        e.load_trf('imp + env[0.2:]', 0, 0.1)
+
     # comparison omitting a lag window resolves to the complement
     comparison = e._eval_trf_x('imp + env @ env[:0.05]')
     assert comparison.x1.name == 'imp + env'
     assert comparison.x0.name == 'imp + env[0.05:]'
+    with pytest.raises(TRFModelError):  # omitted window beyond the model-wide window
+        e.load_model_test('imp + env @ env[0.2:]', 0, 0.1)
 
 
 @requires_mne_sample_data

--- a/eelbrain/_experiment/tests/test_sample_experiment.py
+++ b/eelbrain/_experiment/tests/test_sample_experiment.py
@@ -2180,7 +2180,7 @@ def test_load_trf_term_lags(samples_trf_experiment):
     res = e.load_trf('env[:0.05] + env[0.05:]', 0, 0.1)
     assert res.tstart == (0.05, 0)
     assert res.tstop == (0.1, 0.05)
-    assert [h.name for h in res.h] == ['env[0.05:]', 'env[:0.05]']  # lag windows disambiguate a split predictor
+    assert [h.name for h in res.h] == ['env[0.05:0.1]', 'env[0:0.05]']  # lag windows disambiguate a split predictor
     options = e._trf_options('env[:0.05] + env[0.05:]', 0., 0.1, 'boosting', None, None, False, {})
     ctx = e._resolve_derivative('trf', options=options)
     assert ctx.is_valid()
@@ -2188,20 +2188,24 @@ def test_load_trf_term_lags(samples_trf_experiment):
     assert 'auditory~env' in dependencies
     assert not any('[' in key for key in dependencies)
 
-    # single-term model: scalar lags for the single x
+    # a window shared by all terms is normalized to the model-wide bounds (scalar lags)
     res = e.load_trf('env[0.02:0.08]', 0, 0.1)
     assert res.tstart == 0.02
     assert res.tstop == 0.08
-
-    # all terms with complete windows: the unused model-wide bounds are normalized out of the cache key
-    options = e._trf_options('env[0.02:0.08]', 0., 0.1, 'boosting', None, None, False, {})
-    assert options['tstart'] is None
-    assert options['tstop'] is None
+    ctx = e._resolve_derivative('trf', options=e._trf_options('env[0.02:0.08]', 0., 0.1, 'boosting', None, None, False, {}))
+    assert ctx.options['x'].name == 'env'
+    assert ctx.options['tstart'] == 0.02
+    assert ctx.options['tstop'] == 0.08
+    # ...so equivalent spellings share one cached artifact
     assert e.load_trf('env[0.02:0.08]', 0, 0.5, path_only=True) == e.load_trf('env[0.02:0.08]', 0, 0.1, path_only=True)
-    # a partially specified model keeps the bound a term still uses
-    options = e._trf_options('imp[0:] + env[0.02:]', 0., 0.1, 'boosting', None, None, False, {})
-    assert options['tstart'] is None
-    assert options['tstop'] == 0.1
+    assert e.load_trf('env', 0.02, 0.08, path_only=True) == e.load_trf('env[0.02:0.08]', 0, 0.1, path_only=True)
+    assert e.load_trf('imp[0:0.1] + env[0:0.1]', 0, 0.5, path_only=True) == e.load_trf('imp + env', 0, 0.1, path_only=True)
+    # distinct windows: every term explicit, model-wide bounds normalized out of the cache key
+    ctx = e._resolve_derivative('trf', options=e._trf_options('imp[0:] + env[0.02:]', 0., 0.1, 'boosting', None, None, False, {}))
+    assert ctx.options['x'].name == 'env[0.02:0.1] + imp[0:0.1]'
+    assert ctx.options['tstart'] is None
+    assert ctx.options['tstop'] is None
+    assert e.load_trf('imp[0:0.1] + env[0.02:0.1]', 0, 0.5, path_only=True) == e.load_trf('imp[0:] + env[0.02:]', 0, 0.1, path_only=True)
     with pytest.raises(TRFModelError):  # resolved window of env is empty
         e.load_trf('imp + env[0.2:]', 0, 0.1)
 

--- a/eelbrain/_experiment/trf/estimator.py
+++ b/eelbrain/_experiment/trf/estimator.py
@@ -104,8 +104,8 @@ class Estimator(Configuration):
             self,
             y: NDVar | Datalist,
             xs: list[NDVar | Datalist],
-            tstart: float,
-            tstop: float,
+            tstart: float | list[float],
+            tstop: float | list[float],
             *,
             fwd: NDVar = None,
             cov=None,
@@ -121,9 +121,9 @@ class Estimator(Configuration):
             Predictors, one entry per model term (each a :class:`NDVar` or
             :class:`Datalist` matching ``y``).
         tstart
-            Start of the TRF in seconds.
+            Start of the TRF in seconds (or one value per predictor).
         tstop
-            Stop of the TRF in seconds.
+            Stop of the TRF in seconds (or one value per predictor).
         fwd
             Forward solution (NCRF only).
         cov

--- a/eelbrain/_experiment/trf/job.py
+++ b/eelbrain/_experiment/trf/job.py
@@ -39,9 +39,9 @@ class TRFJob(Job):
     xs
         Predictors, one entry per model term.
     tstart
-        Start of the TRF in seconds.
+        Start of the TRF in seconds (or one value per predictor).
     tstop
-        Stop of the TRF in seconds.
+        Stop of the TRF in seconds (or one value per predictor).
     fwd
         Forward solution (NCRF only).
     cov
@@ -50,8 +50,8 @@ class TRFJob(Job):
     estimator: Estimator
     y: NDVar | Datalist
     xs: list[NDVar | Datalist]
-    tstart: float
-    tstop: float
+    tstart: float | list[float]
+    tstop: float | list[float]
     fwd: NDVar | None = None
     cov: Any | None = None
 

--- a/eelbrain/_experiment/trf/model.py
+++ b/eelbrain/_experiment/trf/model.py
@@ -1,9 +1,24 @@
 # Author: Christian Brodbeck <christianbrodbeck@nyu.edu>
 """Model specification for TRFs
+
+The specification layer is symbolic: :class:`Term`, :class:`Model` and
+:class:`Comparison` are built by parsing and model algebra alone, without
+knowledge of the model-wide ``tstart``/``tstop``. An open lag bound stands for
+the model-wide default and is treated as unbounded by the algebra (overlap,
+subtraction, complement).
+
+Resolving lag windows against concrete ``tstart``/``tstop`` values is a
+separate semantic step: ``resolve_lags`` verifies that every window is
+complete and non-negative (and, for a comparison, that every omitted window is
+contained in the term it was removed from) and drops terms whose resolved
+window is zero-width; ``validate_lags`` requires resolution to be a no-op (the
+backstop used by derivative nodes, whose options are already resolved).
+Individual terms are resolved for fitting with :meth:`Term.with_default_lags`.
 """
 from __future__ import annotations
 
-from collections import abc, Counter
+from collections import Counter, defaultdict
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from functools import cached_property
 from itertools import chain
@@ -11,7 +26,6 @@ from math import inf
 from operator import attrgetter
 from pathlib import Path
 import pickle
-from collections.abc import Callable, Sequence
 
 from pyparsing import DelimitedList, Group, Keyword, ParseException, Literal, Optional, Regex, Word, alphanums, one_of
 
@@ -36,6 +50,14 @@ class Term:
     tstop: float | None = None
 
     def __post_init__(self):
+        for field in ('tstart', 'tstop'):
+            value = getattr(self, field)
+            if value is None:
+                continue
+            ms = round(value * 1000)
+            if abs(value * 1000 - ms) > 1e-6:
+                raise NotImplementedError(f"{self.string}: lag windows with sub-millisecond precision are not supported")
+            object.__setattr__(self, field, ms / 1000)  # snap to the ms grid so that the string form is lossless
         if self.tstart is not None and self.tstop is not None and self.tstart >= self.tstop:
             raise TRFModelError(f"{self.string}: tstart must be smaller than tstop")
 
@@ -46,8 +68,8 @@ class Term:
             string = f"{self.stimulus}~{string}"
         if self.tstart is None and self.tstop is None:
             return string
-        tstart = '' if self.tstart is None else f'{self.tstart:g}'
-        tstop = '' if self.tstop is None else f'{self.tstop:g}'
+        tstart = '' if self.tstart is None else f'{self.tstart:.10g}'
+        tstop = '' if self.tstop is None else f'{self.tstop:.10g}'
         return f"{string}[{tstart}:{tstop}]"
 
     @cached_property
@@ -115,6 +137,14 @@ class Term:
             return self
         return replace(self, tstart=None, tstop=None)
 
+    def with_default_lags(self, tstart: float | None, tstop: float | None) -> Term:
+        """Copy of the term with open lag bounds filled in from the defaults"""
+        return replace(self, tstart=self.tstart if self.tstart is not None else tstart, tstop=self.tstop if self.tstop is not None else tstop)
+
+    def file_label(self, stimulus: str) -> str:
+        """Dependency label of the predictor file backing this term"""
+        return self.without_lags().with_stimulus(stimulus).string
+
     @classmethod
     def _coerce(cls, x: Term | str):
         if isinstance(x, Term):
@@ -122,6 +152,11 @@ class Term:
         elif isinstance(x, str):
             return parse_term(x)
         raise TypeError(x)
+
+    @classmethod
+    def _coerce_and_strip_lags(cls, x: Term | str) -> Term:
+        """Coerce and strip lag-window overrides (which do not affect the predictor file)"""
+        return cls._coerce(x).without_lags()
 
     def _cache_form_(self) -> str:
         """Canonical form for cache keys/fingerprints/manifests"""
@@ -131,37 +166,37 @@ class Term:
         return f"<Term: {self.string}>"
 
 
+def _window(term: Term, tstart: float = None, tstop: float = None) -> tuple[float, float]:
+    """Resolved ``(tstart, tstop)`` lag window of ``term``, filling open bounds from the model-wide defaults (unbounded where those are unknown)"""
+    tstart = term.tstart if term.tstart is not None else (-inf if tstart is None else tstart)
+    tstop = term.tstop if term.tstop is not None else (inf if tstop is None else tstop)
+    return tstart, tstop
+
+
 def _windows_overlap(a: Term, b: Term) -> bool:
-    """Whether the lag windows of two terms overlap (open bounds extend to the model-wide window edge, treated as unbounded)"""
-    start = max(a.tstart if a.tstart is not None else -inf, b.tstart if b.tstart is not None else -inf)
-    stop = min(a.tstop if a.tstop is not None else inf, b.tstop if b.tstop is not None else inf)
-    return start < stop
+    """Whether the lag windows of two terms overlap (open bounds treated as unbounded)"""
+    (a0, a1), (b0, b1) = _window(a), _window(b)
+    return max(a0, b0) < min(a1, b1)
 
 
-def _window_contains(term: Term, omit: Term) -> bool:
+def _window_contains(term: Term, omit: Term, tstart: float = None, tstop: float = None) -> bool:
     """Whether the lag window of ``omit`` lies within the window of ``term``
 
-    Open bounds in ``omit`` inherit the corresponding bound of ``term``; bounds that cannot be compared symbolically (numeric vs. open) are assumed to be contained (verified at fit time).
+    Open bounds in ``omit`` inherit the corresponding (resolved) bound of ``term``; ``tstart``/``tstop`` resolve open bounds in ``term`` (without them, bounds that cannot be compared are assumed to be contained).
     """
-    if omit.tstart is not None:
-        if term.tstart is not None and omit.tstart < term.tstart:
-            return False
-        if term.tstop is not None and omit.tstart >= term.tstop:
-            return False
-    if omit.tstop is not None:
-        if term.tstop is not None and omit.tstop > term.tstop:
-            return False
-        if term.tstart is not None and omit.tstop <= term.tstart:
-            return False
-    return True
+    t0, t1 = _window(term, tstart, tstop)
+    o0, o1 = _window(omit, t0, t1)
+    return t0 <= o0 < t1 and t0 < o1 <= t1
 
 
-def _window_complement(term: Term, omit: Term) -> list[Term]:
+def _window_complement(term: Term, omit: Term, tstart: float = None, tstop: float = None) -> list[Term]:
     """Terms covering the part of ``term``'s lag window that ``omit`` does not cover (0, 1 or 2 terms)"""
+    t0, t1 = _window(term, tstart, tstop)
+    o0, o1 = _window(omit, t0, t1)
     out = []
-    if omit.tstart is not None and (term.tstart is None or omit.tstart > term.tstart):
+    if t0 < o0 < t1:
         out.append(replace(term, tstop=omit.tstart))
-    if omit.tstop is not None and (term.tstop is None or omit.tstop < term.tstop):
+    if t0 < o1 < t1:
         out.append(replace(term, tstart=omit.tstop))
     return out
 
@@ -182,7 +217,7 @@ def _expand_term(
         terms = named_models[term.code].terms
         if term.tstart is not None or term.tstop is not None:
             # distribute lag overrides to member terms; explicit member lags take precedence
-            terms = tuple([replace(term_i, tstart=term_i.tstart if term_i.tstart is not None else term.tstart, tstop=term_i.tstop if term_i.tstop is not None else term.tstop) for term_i in terms])
+            terms = tuple([term_i.with_default_lags(term.tstart, term.tstop) for term_i in terms])
         return terms
     else:
         return term,
@@ -192,16 +227,17 @@ def _expand_term(
 class Model:
     """Model that can be fit to data"""
     terms: tuple[Term, ...]
-    public_name: str = None
 
     def __post_init__(self):
+        # Check for identical duplicates
         counts = Counter([term.string for term in self.terms])
         duplicates = [term for term, count in counts.items() if count > 1]
         if duplicates:
             raise TRFModelError(f"{self.name}: duplicate terms {', '.join(duplicates)}")
-        by_base = {}
+        # Check for duplicate predictors with overlapping lag windows
+        by_base = defaultdict(list)
         for term in self.terms:
-            by_base.setdefault((term.stimulus, term.code), []).append(term)
+            by_base[term.stimulus, term.code].append(term)
         for terms in by_base.values():
             for i, term in enumerate(terms):
                 for other in terms[i + 1:]:
@@ -214,17 +250,8 @@ class Model:
             return '0'
         return ' + '.join(term.string for term in self.terms)
 
-    @cached_property
-    def sorted_key(self) -> str:
-        return '+'.join(sorted([term.string for term in self.terms]))
-
     def sorted(self) -> Model:
         return Model(tuple(sorted(self.terms, key=attrgetter('string'))))
-
-    @cached_property
-    def dataset_based_key(self):
-        term_keys = [Dataset.as_key(term.string) for term in self.terms]
-        return '+'.join(sorted(term_keys))
 
     @cached_property
     def term_names(self):
@@ -254,7 +281,25 @@ class Model:
         return Model(self.terms + other.terms)
 
     def __sub__(self, other: Model) -> Model:
-        """Remove terms; a term with a lag window removes that window from the matching term, keeping the complement"""
+        return self.subtract(other)
+
+    def subtract(
+            self,
+            other: Model,
+            tstart: float = None,
+            tstop: float = None,
+    ) -> Model:
+        """Remove terms; a term with a lag window removes that window from the matching term, keeping the complement
+
+        Parameters
+        ----------
+        other
+            Terms to remove.
+        tstart
+            Model-wide lag-window start, used to resolve open bounds when verifying that a removed lag window is contained in the term it is removed from.
+        tstop
+            Model-wide lag-window stop (see ``tstart``).
+        """
         terms = list(self.terms)
         for omit in other.terms:
             candidates = [term for term in terms if term.stimulus == omit.stimulus and term.code == omit.code]
@@ -264,13 +309,12 @@ class Model:
                 for term in candidates:
                     terms.remove(term)
                 continue
-            containing = [term for term in candidates if _window_contains(term, omit)]
-            if not containing:
+            # candidate windows are disjoint, so at most one can contain the omitted window
+            containing = next((term for term in candidates if _window_contains(term, omit, tstart, tstop)), None)
+            if containing is None:
                 raise TRFModelError(f"{self.name} - {other.name}: lag window of {omit.string} is not contained in any single term ({', '.join(term.string for term in candidates)})")
-            elif len(containing) > 1:
-                raise TRFModelError(f"{self.name} - {other.name}: lag window of {omit.string} is ambiguous (contained in {', '.join(term.string for term in containing)})")
-            index = terms.index(containing[0])
-            terms[index:index + 1] = _window_complement(containing[0], omit)
+            index = terms.index(containing)
+            terms[index:index + 1] = _window_complement(containing, omit, tstart, tstop)
         return Model(tuple(terms))
 
     def __hash__(self):
@@ -285,16 +329,33 @@ class Model:
             return x
         elif isinstance(x, str):
             return cls.from_string(x)
-        elif isinstance(x, abc.Sequence):
+        elif isinstance(x, Sequence):
             return cls(tuple(Term._coerce(term) for term in x))
         raise TypeError(x)
 
     def difference(self, other: Model) -> Model:
-        terms = [term for term in self.terms if term not in other.terms]
+        """Terms, and parts of lag windows, in ``self`` but not in ``other``"""
+        terms = []
+        for term in self.terms:
+            pieces = [term]
+            for omit in other.terms:
+                if (omit.stimulus, omit.code) != (term.stimulus, term.code):
+                    continue
+                pieces = [piece_i for piece in pieces for piece_i in (_window_complement(piece, omit) if _windows_overlap(piece, omit) else [piece])]
+            terms.extend(pieces)
         return Model(tuple(terms))
 
     def intersection(self, other: Model) -> Model:
-        terms = [term for term in self.terms if term in other.terms]
+        """Terms, and parts of lag windows, in both ``self`` and ``other``"""
+        terms = []
+        for term in self.terms:
+            for shared in other.terms:
+                if (shared.stimulus, shared.code) != (term.stimulus, term.code) or not _windows_overlap(term, shared):
+                    continue
+                (t0, t1), (s0, s1) = _window(term), _window(shared)
+                tstart = None if max(t0, s0) == -inf else max(t0, s0)
+                tstop = None if min(t1, s1) == inf else min(t1, s1)
+                terms.append(replace(term, tstart=tstart, tstop=tstop))
         return Model(tuple(terms))
 
     def initialize(self, named_models: dict[str, Model]) -> Model:
@@ -303,26 +364,57 @@ class Model:
 
     def term_table(self) -> fmtxt.Table:
         show_stimulus = any(term.stimulus for term in self.terms)
-        t = fmtxt.Table('rl' * (1 + show_stimulus))
+        show_lags = any(term.tstart is not None or term.tstop is not None for term in self.terms)
+        t = fmtxt.Table('r' + 'l' * show_stimulus + 'l' + 'rr' * show_lags)
         t.cell('#')
         if show_stimulus:
             t.cell('Stimulus')
         t.cell('Code')
+        if show_lags:
+            t.cells('tstart', 'tstop')
         t.midrule()
         for i, term in enumerate(self.terms):
             t.cell(i)
             if show_stimulus:
                 t.cell(term.stimulus)
             t.cell(term.code)
+            if show_lags:
+                t.cell('' if term.tstart is None else f'{term.tstart:g}')
+                t.cell('' if term.tstop is None else f'{term.tstop:g}')
         return t
 
-    def without(self, term: str) -> Model:
-        terms = list(self.terms)
-        names = [term.string for term in terms]
-        if term not in names:
-            raise ValueError(f"{term}: not in {self.name}")
-        del terms[names.index(term)]
+    def resolve_lags(self, tstart: float | None, tstop: float | None) -> Model:
+        """Resolve the terms' lag windows against the model-wide defaults
+
+        Verifies that every term's lag window is complete and non-negative, and
+        drops terms whose resolved window is zero-width (they cover no lags,
+        e.g. the complement of an omitted window with a bound at the model-wide
+        bound).
+        """
+        terms = []
+        for term in self.terms:
+            if term.tstart is None and tstart is None:
+                raise TRFModelError(f"{self.name}: no tstart for {term.string} (set tstart, or specify it in the term's lag window)")
+            if term.tstop is None and tstop is None:
+                raise TRFModelError(f"{self.name}: no tstop for {term.string} (set tstop, or specify it in the term's lag window)")
+            t0, t1 = _window(term, tstart, tstop)
+            if t0 > t1:
+                raise TRFModelError(f"{self.name}: lag window of {term.string} is empty given {tstart=} and {tstop=}")
+            elif t0 == t1:
+                continue  # zero-width window: covers no lags
+            terms.append(term)
+        if len(terms) == len(self.terms):
+            return self
+        elif not terms:
+            raise TRFModelError(f"{self.name}: no term covers any lags given {tstart=} and {tstop=}")
         return Model(tuple(terms))
+
+    def validate_lags(self, tstart: float | None, tstop: float | None) -> None:
+        """Verify that every term has a complete, non-empty lag window given the model-wide defaults"""
+        resolved = self.resolve_lags(tstart, tstop)
+        if resolved is not self:
+            dropped = [term.string for term in self.terms if term not in resolved.terms]
+            raise TRFModelError(f"{self.name}: lag windows of {', '.join(dropped)} are empty given {tstart=} and {tstop=}")
 
 
 @dataclass
@@ -421,7 +513,7 @@ class OmitComparison(ComparisonSpec):
         x = self.x.initialize(named_models)
         x_omit = self.x_omit.initialize(named_models)
         x0 = x - x_omit
-        return Comparison(x, x0, 1, public_name)
+        return Comparison(x, x0, 1, public_name, ((x, x_omit),))
 
 
 @dataclass
@@ -442,7 +534,7 @@ class Omit2Comparison(ComparisonSpec):
         #     x0_reduced > x1_reduced
         x1 = x - x0_omit
         x0 = x - x1_omit
-        return Comparison(x1, x0, TAIL[self.operator], public_name)
+        return Comparison(x1, x0, TAIL[self.operator], public_name, ((x, x1_omit), (x, x0_omit)))
 
 
 @dataclass
@@ -487,6 +579,7 @@ class Comparison:
     x0: Model
     tail: int = 1
     public_name: str = None
+    subtractions: tuple[tuple[Model, Model], ...] = ()  # (full model, omitted terms) pairs behind reduced models, for validate_lags
 
     @cached_property
     def operator(self) -> str:
@@ -538,7 +631,30 @@ class Comparison:
 
     def sorted(self) -> Comparison:
         """Copy with terms in both models sorted for stable cache identity"""
-        return Comparison(self.x1.sorted(), self.x0.sorted(), self.tail, self.public_name)
+        return Comparison(self.x1.sorted(), self.x0.sorted(), self.tail, self.public_name, self.subtractions)
+
+    def resolve_lags(self, tstart: float | None, tstop: float | None) -> Comparison:
+        """Resolve the models' lag windows against the model-wide defaults
+
+        Verifies that every omitted lag window is contained in the term it was
+        removed from (see :meth:`Model.subtract`), and resolves both models
+        (see :meth:`Model.resolve_lags`), dropping terms whose resolved window
+        is zero-width.
+        """
+        for x, omit in self.subtractions:
+            x.subtract(omit, tstart, tstop)
+        x1 = self.x1.resolve_lags(tstart, tstop)
+        x0 = self.x0.resolve_lags(tstart, tstop)
+        if x1 is self.x1 and x0 is self.x0:
+            return self
+        return replace(self, x1=x1, x0=x0)
+
+    def validate_lags(self, tstart: float | None, tstop: float | None) -> None:
+        """Verify that :meth:`resolve_lags` is a no-op for the model-wide defaults"""
+        resolved = self.resolve_lags(tstart, tstop)
+        if resolved is not self:
+            dropped = [term.string for model, resolved_model in zip(self.models, resolved.models) for term in model.terms if term not in resolved_model.terms]
+            raise TRFModelError(f"{self.name}: lag windows of {', '.join(dropped)} are empty given {tstart=} and {tstop=}")
 
     def _cache_form_(self) -> str:
         """Canonical expanded form for cache keys and manifests"""

--- a/eelbrain/_experiment/trf/model.py
+++ b/eelbrain/_experiment/trf/model.py
@@ -157,11 +157,6 @@ class Term:
             return parse_term(x)
         raise TypeError(x)
 
-    @classmethod
-    def _coerce_and_strip_lags(cls, x: Term | str) -> Term:
-        """Coerce and strip lag-window overrides (which do not affect the predictor file)"""
-        return cls._coerce(x).without_lags()
-
     def _cache_form_(self) -> str:
         """Canonical form for cache keys/fingerprints/manifests"""
         return self.string
@@ -205,13 +200,20 @@ def _window_complement(term: Term, omit: Term) -> list[Term]:
     return out
 
 
-def _extract_uniform_lags(models: Sequence[Model]) -> tuple[list[Model], float, float] | None:
-    """Bare models and their shared window, when all terms in ``models`` share one explicit lag window (else ``None``)"""
+def _shared_window(models: Sequence[Model]) -> tuple[float, float] | None:
+    """The single explicit lag window shared by every term in ``models`` (else ``None``)"""
     windows = {(term.tstart, term.tstop) for model in models for term in model.terms}
     if len(windows) != 1:
         return None
-    (tstart, tstop), = windows
-    return [Model(tuple(term.without_lags() for term in model.terms)) for model in models], tstart, tstop
+    return windows.pop()
+
+
+def _require_bounds(name: str, tstart: float | None, tstop: float | None) -> None:
+    """Validate the model-wide bounds for a model/comparison in which no term has a lag window"""
+    if tstart is None or tstop is None:
+        raise TRFModelError(f"{name}: tstart and tstop are required when no term has a lag window ({tstart=}, {tstop=})")
+    if tstart >= tstop:
+        raise TRFModelError(f"{name}: empty lag window ({tstart=}, {tstop=})")
 
 
 def _expand_term(
@@ -369,6 +371,10 @@ class Model:
             return self
         return Model(terms)
 
+    def without_lags(self) -> Model:
+        """Copy of the model with all lag-window overrides stripped"""
+        return Model(tuple(term.without_lags() for term in self.terms))
+
     def term_table(self) -> fmtxt.Table:
         show_stimulus = any(term.stimulus for term in self.terms)
         show_lags = any(term.tstart is not None or term.tstop is not None for term in self.terms)
@@ -419,17 +425,13 @@ class Model:
         """Canonical ``(model, tstart, tstop)`` for cache identity"""
         # A model without lag overrides keeps the model-wide bounds
         if not any(term.tstart is not None or term.tstop is not None for term in self.terms):
-            if tstart is None or tstop is None:
-                raise TRFModelError(f"{self.name}: tstart and tstop are required for a model without term lag windows ({tstart=}, {tstop=})")
-            if tstart >= tstop:
-                raise TRFModelError(f"{self.name}: empty lag window ({tstart=}, {tstop=})")
+            _require_bounds(self.name, tstart, tstop)
             return self, tstart, tstop
         # With any override present, all windows are resolved
         resolved = self.resolve_lags(tstart, tstop)
-        # Catch tstart/tstop shared by all terms
-        if extracted := _extract_uniform_lags([resolved]):
-            (model,), tstart, tstop = extracted
-            return model, tstart, tstop
+        # A window shared by all terms moves to the model-wide bounds
+        if window := _shared_window([resolved]):
+            return resolved.without_lags(), *window
         return resolved, None, None
 
 
@@ -519,8 +521,7 @@ class Omit2Comparison(ComparisonSpec):
         x = self.x.initialize(named_models)
         x1_omit = self.x1_omit.initialize(named_models)
         x0_omit = self.x0_omit.initialize(named_models)
-        # x - x1_reduced > x - x0_reduced
-        #     x0_reduced > x1_reduced
+        # each side is tested by omitting the *other* side's term: x1 keeps x1_omit by omitting x0_omit, and vice versa
         x1 = x - x0_omit
         x0 = x - x1_omit
         return Comparison(x1, x0, TAIL[self.operator], public_name, omit_base=x, omits=(x0_omit, x1_omit))
@@ -659,15 +660,12 @@ class Comparison:
     ) -> tuple[Comparison, float | None, float | None]:
         """Canonical ``(comparison, tstart, tstop)`` for cache identity"""
         if not any(term.tstart is not None or term.tstop is not None for model in self.models for term in model.terms):
-            if tstart is None or tstop is None:
-                raise TRFModelError(f"{self.name}: tstart and tstop are required for a comparison without term lag windows ({tstart=}, {tstop=})")
-            if tstart >= tstop:
-                raise TRFModelError(f"{self.name}: empty lag window ({tstart=}, {tstop=})")
+            _require_bounds(self.name, tstart, tstop)
             return self, tstart, tstop
         resolved = self.resolve_lags(tstart, tstop)
-        if extracted := _extract_uniform_lags(resolved.models):
-            (x1, x0), tstart, tstop = extracted
-            return replace(resolved, x1=x1, x0=x0), tstart, tstop
+        # A window shared by all terms in both models moves to the model-wide bounds
+        if window := _shared_window(resolved.models):
+            return replace(resolved, x1=resolved.x1.without_lags(), x0=resolved.x0.without_lags()), *window
         return resolved, None, None
 
     def _cache_form_(self) -> str:

--- a/eelbrain/_experiment/trf/model.py
+++ b/eelbrain/_experiment/trf/model.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pickle
 from collections.abc import Callable, Sequence
 
-from pyparsing import DelimitedList, Keyword, ParseException, Literal, Optional, Word, alphanums, one_of
+from pyparsing import DelimitedList, Group, Keyword, ParseException, Literal, Optional, Regex, Word, alphanums, one_of
 
 from ..._data_obj import Dataset
 from ... import fmtxt
@@ -31,12 +31,23 @@ class TRFModelError(Exception):
 class Term:
     stimulus: str | None
     code: str
+    tstart: float | None = None  # lag-window override; None: use the model-wide option
+    tstop: float | None = None
+
+    def __post_init__(self):
+        if self.tstart is not None and self.tstop is not None and self.tstart >= self.tstop:
+            raise TRFModelError(f"{self.string}: tstart must be smaller than tstop")
 
     @cached_property
     def string(self) -> str:
+        string = self.code
         if self.stimulus:
-            return f"{self.stimulus}~{self.code}"
-        return self.code
+            string = f"{self.stimulus}~{string}"
+        if self.tstart is None and self.tstop is None:
+            return string
+        tstart = '' if self.tstart is None else f'{self.tstart:g}'
+        tstop = '' if self.tstop is None else f'{self.tstop:g}'
+        return f"{string}[{tstart}:{tstop}]"
 
     @cached_property
     def key(self) -> str:
@@ -85,7 +96,7 @@ class Term:
     @cached_property
     def uts_file_name(self) -> str:
         """File name (without extension) of the predictor file backing this term"""
-        return self.string
+        return self.without_lags().string
 
     @cached_property
     def nuts_file_name(self) -> str:
@@ -96,6 +107,12 @@ class Term:
     def with_stimulus(self, stimulus: str) -> Term:
         """Copy of the term with a different stimulus"""
         return replace(self, stimulus=stimulus)
+
+    def without_lags(self) -> Term:
+        """Copy of the term without lag-window overrides"""
+        if self.tstart is None and self.tstop is None:
+            return self
+        return replace(self, tstart=None, tstop=None)
 
     @classmethod
     def _coerce(cls, x: Term | str):
@@ -126,7 +143,11 @@ def _expand_term(
         terms = _expand_term(replace(term, code=term.code[:-5]), named_models)
         return tuple([replace(term, code=f'{term.code}-step') for term in terms])
     elif term.code in named_models:
-        return named_models[term.code].terms
+        terms = named_models[term.code].terms
+        if term.tstart is not None or term.tstop is not None:
+            # distribute lag overrides to member terms; explicit member lags take precedence
+            terms = tuple([replace(term_i, tstart=term_i.tstart if term_i.tstart is not None else term.tstart, tstop=term_i.tstop if term_i.tstop is not None else term.tstop) for term_i in terms])
+        return terms
     else:
         return term,
 
@@ -504,8 +525,10 @@ class Comparison:
 name = Word(alphanums + '_')
 stimulus = Word(alphanums + '_', alphanums + '_-')
 stimulus_prefix = stimulus + Literal('~').suppress().leave_whitespace()
-term = Optional(stimulus_prefix, '') + DelimitedList(name, '-', combine=True, min=1)
-term.add_parse_action(lambda s, l, t: Term(t[0] or None, t[1]))
+lag_value = Regex(r'-?(\d+\.?\d*|\.\d+)').add_parse_action(lambda s, l, t: float(t[0]))
+lags = Literal('[').suppress() + Optional(lag_value, None) + Literal(':').suppress() + Optional(lag_value, None) + Literal(']').suppress()
+term = Optional(stimulus_prefix, '') + DelimitedList(name, '-', combine=True, min=1) + Optional(Group(lags), None)
+term.add_parse_action(lambda s, l, t: Term(t[0] or None, t[1], *(t[2] if t[2] is not None else (None, None))))
 
 # model
 model = DelimitedList(term, '+').add_parse_action(lambda s, l, t: Model(tuple(t)))

--- a/eelbrain/_experiment/trf/model.py
+++ b/eelbrain/_experiment/trf/model.py
@@ -8,18 +8,22 @@ the model-wide default and is treated as unbounded by the algebra (overlap,
 subtraction, complement).
 
 Resolving lag windows against concrete ``tstart``/``tstop`` values is a
-separate semantic step: ``resolve_lags`` verifies that every window is
-complete and non-negative (and, for a comparison, that every omitted window is
-contained in the term it was removed from) and drops terms whose resolved
-window is zero-width; ``validate_lags`` requires resolution to be a no-op (the
-backstop used by derivative nodes, whose options are already resolved).
-Individual terms are resolved for fitting with :meth:`Term.with_default_lags`.
+separate semantic step: ``resolve_lags`` fills every open bound in from the
+model-wide defaults (re-deriving an omit comparison's reduced model, so that
+omitted windows are verified against the concrete windows they are removed
+from). ``normalize_lags`` puts ``(x, tstart, tstop)`` into the canonical form
+used for cache identity: a model without lag overrides keeps the model-wide
+bounds; with overrides, a window shared by all terms moves to the model-wide
+bounds, and otherwise every term carries its explicit window and the
+model-wide bounds are ``None``. The TRF derivative nodes apply
+``normalize_lags`` when a request is resolved, so equivalent spellings share
+one cached artifact.
 """
 from __future__ import annotations
 
 from collections import Counter, defaultdict
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from functools import cached_property
 from itertools import chain
 from math import inf
@@ -50,14 +54,14 @@ class Term:
     tstop: float | None = None
 
     def __post_init__(self):
-        for field in ('tstart', 'tstop'):
-            value = getattr(self, field)
+        for attr in ('tstart', 'tstop'):
+            value = getattr(self, attr)
             if value is None:
                 continue
             ms = round(value * 1000)
             if abs(value * 1000 - ms) > 1e-6:
-                raise NotImplementedError(f"{self.string}: lag windows with sub-millisecond precision are not supported")
-            object.__setattr__(self, field, ms / 1000)  # snap to the ms grid so that the string form is lossless
+                raise TRFModelError(f"{self.string}: lag windows with sub-millisecond precision are not supported")
+            object.__setattr__(self, attr, ms / 1000)  # snap to the ms grid so that the string form is lossless
         if self.tstart is not None and self.tstop is not None and self.tstart >= self.tstop:
             raise TRFModelError(f"{self.string}: tstart must be smaller than tstop")
 
@@ -166,7 +170,7 @@ class Term:
         return f"<Term: {self.string}>"
 
 
-def _window(term: Term, tstart: float = None, tstop: float = None) -> tuple[float, float]:
+def _window(term: Term, tstart: float | None = None, tstop: float | None = None) -> tuple[float, float]:
     """Resolved ``(tstart, tstop)`` lag window of ``term``, filling open bounds from the model-wide defaults (unbounded where those are unknown)"""
     tstart = term.tstart if term.tstart is not None else (-inf if tstart is None else tstart)
     tstop = term.tstop if term.tstop is not None else (inf if tstop is None else tstop)
@@ -179,19 +183,19 @@ def _windows_overlap(a: Term, b: Term) -> bool:
     return max(a0, b0) < min(a1, b1)
 
 
-def _window_contains(term: Term, omit: Term, tstart: float = None, tstop: float = None) -> bool:
+def _window_contains(term: Term, omit: Term) -> bool:
     """Whether the lag window of ``omit`` lies within the window of ``term``
 
-    Open bounds in ``omit`` inherit the corresponding (resolved) bound of ``term``; ``tstart``/``tstop`` resolve open bounds in ``term`` (without them, bounds that cannot be compared are assumed to be contained).
+    Open bounds in ``omit`` inherit the corresponding bound of ``term``; open bounds in ``term`` compare as unbounded.
     """
-    t0, t1 = _window(term, tstart, tstop)
+    t0, t1 = _window(term)
     o0, o1 = _window(omit, t0, t1)
     return t0 <= o0 < t1 and t0 < o1 <= t1
 
 
-def _window_complement(term: Term, omit: Term, tstart: float = None, tstop: float = None) -> list[Term]:
+def _window_complement(term: Term, omit: Term) -> list[Term]:
     """Terms covering the part of ``term``'s lag window that ``omit`` does not cover (0, 1 or 2 terms)"""
-    t0, t1 = _window(term, tstart, tstop)
+    t0, t1 = _window(term)
     o0, o1 = _window(omit, t0, t1)
     out = []
     if t0 < o0 < t1:
@@ -199,6 +203,15 @@ def _window_complement(term: Term, omit: Term, tstart: float = None, tstop: floa
     if t0 < o1 < t1:
         out.append(replace(term, tstart=omit.tstop))
     return out
+
+
+def _extract_uniform_lags(models: Sequence[Model]) -> tuple[list[Model], float, float] | None:
+    """Bare models and their shared window, when all terms in ``models`` share one explicit lag window (else ``None``)"""
+    windows = {(term.tstart, term.tstop) for model in models for term in model.terms}
+    if len(windows) != 1:
+        return None
+    (tstart, tstop), = windows
+    return [Model(tuple(term.without_lags() for term in model.terms)) for model in models], tstart, tstop
 
 
 def _expand_term(
@@ -281,25 +294,7 @@ class Model:
         return Model(self.terms + other.terms)
 
     def __sub__(self, other: Model) -> Model:
-        return self.subtract(other)
-
-    def subtract(
-            self,
-            other: Model,
-            tstart: float = None,
-            tstop: float = None,
-    ) -> Model:
-        """Remove terms; a term with a lag window removes that window from the matching term, keeping the complement
-
-        Parameters
-        ----------
-        other
-            Terms to remove.
-        tstart
-            Model-wide lag-window start, used to resolve open bounds when verifying that a removed lag window is contained in the term it is removed from.
-        tstop
-            Model-wide lag-window stop (see ``tstart``).
-        """
+        """Remove terms; a term with a lag window removes that window from the matching term, keeping the complement"""
         terms = list(self.terms)
         for omit in other.terms:
             candidates = [term for term in terms if term.stimulus == omit.stimulus and term.code == omit.code]
@@ -310,11 +305,11 @@ class Model:
                     terms.remove(term)
                 continue
             # candidate windows are disjoint, so at most one can contain the omitted window
-            containing = next((term for term in candidates if _window_contains(term, omit, tstart, tstop)), None)
+            containing = next((term for term in candidates if _window_contains(term, omit)), None)
             if containing is None:
                 raise TRFModelError(f"{self.name} - {other.name}: lag window of {omit.string} is not contained in any single term ({', '.join(term.string for term in candidates)})")
             index = terms.index(containing)
-            terms[index:index + 1] = _window_complement(containing, omit, tstart, tstop)
+            terms[index:index + 1] = _window_complement(containing, omit)
         return Model(tuple(terms))
 
     def __hash__(self):
@@ -324,14 +319,20 @@ class Model:
         return self.name == other.name
 
     @classmethod
-    def coerce(cls, x: Model | str | Sequence) -> Model:
+    def coerce(
+            cls,
+            x: Model | str | Sequence,
+            named_models: dict[str, Model] = {},
+    ) -> Model:
         if isinstance(x, cls):
             return x
         elif isinstance(x, str):
-            return cls.from_string(x)
+            model = cls.from_string(x)
         elif isinstance(x, Sequence):
-            return cls(tuple(Term._coerce(term) for term in x))
-        raise TypeError(x)
+            model = cls(tuple(Term._coerce(term) for term in x))
+        else:
+            raise TypeError(x)
+        return model.initialize(named_models)
 
     def difference(self, other: Model) -> Model:
         """Terms, and parts of lag windows, in ``self`` but not in ``other``"""
@@ -384,12 +385,11 @@ class Model:
         return t
 
     def resolve_lags(self, tstart: float | None, tstop: float | None) -> Model:
-        """Resolve the terms' lag windows against the model-wide defaults
+        """Copy with every lag window resolved to explicit bounds from the model-wide defaults
 
-        Verifies that every term's lag window is complete and non-negative, and
-        drops terms whose resolved window is zero-width (they cover no lags,
-        e.g. the complement of an omitted window with a bound at the model-wide
-        bound).
+        Raises :class:`TRFModelError` when a bound is neither set on the term
+        nor available as a model-wide default, and when a resolved window is
+        empty.
         """
         terms = []
         for term in self.terms:
@@ -398,50 +398,33 @@ class Model:
             if term.tstop is None and tstop is None:
                 raise TRFModelError(f"{self.name}: no tstop for {term.string} (set tstop, or specify it in the term's lag window)")
             t0, t1 = _window(term, tstart, tstop)
-            if t0 > t1:
+            if t0 >= t1:
                 raise TRFModelError(f"{self.name}: lag window of {term.string} is empty given {tstart=} and {tstop=}")
-            elif t0 == t1:
-                continue  # zero-width window: covers no lags
-            terms.append(term)
-        if len(terms) == len(self.terms):
+            terms.append(term.with_default_lags(tstart, tstop))
+        if terms == list(self.terms):
             return self
-        elif not terms:
-            raise TRFModelError(f"{self.name}: no term covers any lags given {tstart=} and {tstop=}")
         return Model(tuple(terms))
 
-    def validate_lags(self, tstart: float | None, tstop: float | None) -> None:
-        """Verify that every term has a complete, non-empty lag window given the model-wide defaults"""
-        resolved = self.resolve_lags(tstart, tstop)
-        if resolved is not self:
-            dropped = [term.string for term in self.terms if term not in resolved.terms]
-            raise TRFModelError(f"{self.name}: lag windows of {', '.join(dropped)} are empty given {tstart=} and {tstop=}")
-
-
-@dataclass
-class ModelExpression:
-    """Model specification using abbreviations"""
-    base: Model
-    subtract: Term = None
-
-    @classmethod
-    def from_string(
-            cls,
-            string: str,
-    ) -> ModelExpression:
-        try:
-            return model_expr.parse_string(string, True)[0]
-        except ParseException:
-            raise TRFModelError(f"{string!r}: invalid Model")
-
-    def initialize(
+    def normalize_lags(
             self,
-            named_models: dict[str, Model],
-    ) -> Model:
-        """Expand into full model"""
-        base = self.base.initialize(named_models)
-        if not self.subtract:
-            return base
-        return base - Model(_expand_term(self.subtract, named_models))
+            tstart: float | None,
+            tstop: float | None,
+    ) -> tuple[Model, float | None, float | None]:
+        """Canonical ``(model, tstart, tstop)`` for cache identity"""
+        # A model without lag overrides keeps the model-wide bounds
+        if not any(term.tstart is not None or term.tstop is not None for term in self.terms):
+            if tstart is None or tstop is None:
+                raise TRFModelError(f"{self.name}: tstart and tstop are required for a model without term lag windows ({tstart=}, {tstop=})")
+            if tstart >= tstop:
+                raise TRFModelError(f"{self.name}: empty lag window ({tstart=}, {tstop=})")
+            return self, tstart, tstop
+        # With any override present, all windows are resolved
+        resolved = self.resolve_lags(tstart, tstop)
+        # Catch tstart/tstop shared by all terms
+        if extracted := _extract_uniform_lags([resolved]):
+            (model,), tstart, tstop = extracted
+            return model, tstart, tstop
+        return resolved, None, None
 
 
 def model_comparison_table(x1: Model, x0: Model, x1_name: str = 'x1', x0_name: str = 'x0'):
@@ -513,7 +496,7 @@ class OmitComparison(ComparisonSpec):
         x = self.x.initialize(named_models)
         x_omit = self.x_omit.initialize(named_models)
         x0 = x - x_omit
-        return Comparison(x, x0, 1, public_name, ((x, x_omit),))
+        return Comparison(x, x0, 1, public_name, omit_base=x, omits=(None, x_omit))
 
 
 @dataclass
@@ -534,7 +517,7 @@ class Omit2Comparison(ComparisonSpec):
         #     x0_reduced > x1_reduced
         x1 = x - x0_omit
         x0 = x - x1_omit
-        return Comparison(x1, x0, TAIL[self.operator], public_name, ((x, x1_omit), (x, x0_omit)))
+        return Comparison(x1, x0, TAIL[self.operator], public_name, omit_base=x, omits=(x0_omit, x1_omit))
 
 
 @dataclass
@@ -579,7 +562,9 @@ class Comparison:
     x0: Model
     tail: int = 1
     public_name: str = None
-    subtractions: tuple[tuple[Model, Model], ...] = ()  # (full model, omitted terms) pairs behind reduced models, for validate_lags
+    # Construction record of an omit comparison, needed because omitted terms treat bounds differently; Example: 'a + b @ b[0.6:]' with tstart=0, tstop=0.5 -> x1 = 'a + b[:0.6]'
+    omit_base: Model = field(default=None, compare=False)
+    omits: tuple[Model | None, Model | None] = field(default=(None, None), compare=False)
 
     @cached_property
     def operator(self) -> str:
@@ -591,14 +576,23 @@ class Comparison:
 
     @cached_property
     def common_base(self) -> Model:
+        """Terms, and parts of lag windows, shared by both models
+
+        Like :attr:`x1_only` and :attr:`x0_only`, exact only when the lag
+        windows are explicit (see :meth:`resolve_lags`): an open bound compares
+        as unbounded, so a term with an open bound can misattribute lags that
+        the model-wide window would exclude.
+        """
         return self.x1.intersection(self.x0)
 
     @cached_property
     def x1_only(self) -> Model:
+        """Terms, and parts of lag windows, only in ``x1`` (see :attr:`common_base`)"""
         return self.x1.difference(self.x0)
 
     @cached_property
     def x0_only(self) -> Model:
+        """Terms, and parts of lag windows, only in ``x0`` (see :attr:`common_base`)"""
         return self.x0.difference(self.x1)
 
     @cached_property
@@ -631,30 +625,43 @@ class Comparison:
 
     def sorted(self) -> Comparison:
         """Copy with terms in both models sorted for stable cache identity"""
-        return Comparison(self.x1.sorted(), self.x0.sorted(), self.tail, self.public_name, self.subtractions)
+        return replace(self, x1=self.x1.sorted(), x0=self.x0.sorted())
 
     def resolve_lags(self, tstart: float | None, tstop: float | None) -> Comparison:
-        """Resolve the models' lag windows against the model-wide defaults
+        """Copy with both models' lag windows resolved to explicit bounds (see :meth:`Model.resolve_lags`)
 
-        Verifies that every omitted lag window is contained in the term it was
-        removed from (see :meth:`Model.subtract`), and resolves both models
-        (see :meth:`Model.resolve_lags`), dropping terms whose resolved window
-        is zero-width.
+        For an omit comparison, the reduced model is re-derived by subtracting
+        the omitted terms from the resolved full model, so that every omitted
+        window is verified against, and its complement computed within, the
+        concrete window it is removed from.
         """
-        for x, omit in self.subtractions:
-            x.subtract(omit, tstart, tstop)
-        x1 = self.x1.resolve_lags(tstart, tstop)
-        x0 = self.x0.resolve_lags(tstart, tstop)
-        if x1 is self.x1 and x0 is self.x0:
+        if self.omit_base is None:
+            x1 = self.x1.resolve_lags(tstart, tstop)
+            x0 = self.x0.resolve_lags(tstart, tstop)
+        else:
+            base = self.omit_base.resolve_lags(tstart, tstop)
+            x1, x0 = (base if omit is None else base - omit for omit in self.omits)
+        if x1 == self.x1 and x0 == self.x0:
             return self
         return replace(self, x1=x1, x0=x0)
 
-    def validate_lags(self, tstart: float | None, tstop: float | None) -> None:
-        """Verify that :meth:`resolve_lags` is a no-op for the model-wide defaults"""
+    def normalize_lags(
+            self,
+            tstart: float | None,
+            tstop: float | None,
+    ) -> tuple[Comparison, float | None, float | None]:
+        """Canonical ``(comparison, tstart, tstop)`` for cache identity"""
+        if not any(term.tstart is not None or term.tstop is not None for model in self.models for term in model.terms):
+            if tstart is None or tstop is None:
+                raise TRFModelError(f"{self.name}: tstart and tstop are required for a comparison without term lag windows ({tstart=}, {tstop=})")
+            if tstart >= tstop:
+                raise TRFModelError(f"{self.name}: empty lag window ({tstart=}, {tstop=})")
+            return self, tstart, tstop
         resolved = self.resolve_lags(tstart, tstop)
-        if resolved is not self:
-            dropped = [term.string for model, resolved_model in zip(self.models, resolved.models) for term in model.terms if term not in resolved_model.terms]
-            raise TRFModelError(f"{self.name}: lag windows of {', '.join(dropped)} are empty given {tstart=} and {tstop=}")
+        if extracted := _extract_uniform_lags(resolved.models):
+            (x1, x0), tstart, tstop = extracted
+            return replace(resolved, x1=x1, x0=x0), tstart, tstop
+        return resolved, None, None
 
     def _cache_form_(self) -> str:
         """Canonical expanded form for cache keys and manifests"""
@@ -701,9 +708,6 @@ term.add_parse_action(lambda s, l, t: Term(t[0] or None, t[1], *(t[2] if t[2] is
 
 # model
 model = DelimitedList(term, '+').add_parse_action(lambda s, l, t: Model(tuple(t)))
-subtract_term = Literal('-').suppress() + term
-model_expr = model + Optional(subtract_term)
-model_expr.add_parse_action(lambda s, l, t: ModelExpression(*t))
 null_model = Keyword('0', ident_chars=alphanums + '_-~').add_parse_action(lambda s, l, t: Model(()))
 
 # comparison

--- a/eelbrain/_experiment/trf/model.py
+++ b/eelbrain/_experiment/trf/model.py
@@ -7,6 +7,7 @@ from collections import abc, Counter
 from dataclasses import dataclass, replace
 from functools import cached_property
 from itertools import chain
+from math import inf
 from operator import attrgetter
 from pathlib import Path
 import pickle
@@ -130,6 +131,41 @@ class Term:
         return f"<Term: {self.string}>"
 
 
+def _windows_overlap(a: Term, b: Term) -> bool:
+    """Whether the lag windows of two terms overlap (open bounds extend to the model-wide window edge, treated as unbounded)"""
+    start = max(a.tstart if a.tstart is not None else -inf, b.tstart if b.tstart is not None else -inf)
+    stop = min(a.tstop if a.tstop is not None else inf, b.tstop if b.tstop is not None else inf)
+    return start < stop
+
+
+def _window_contains(term: Term, omit: Term) -> bool:
+    """Whether the lag window of ``omit`` lies within the window of ``term``
+
+    Open bounds in ``omit`` inherit the corresponding bound of ``term``; bounds that cannot be compared symbolically (numeric vs. open) are assumed to be contained (verified at fit time).
+    """
+    if omit.tstart is not None:
+        if term.tstart is not None and omit.tstart < term.tstart:
+            return False
+        if term.tstop is not None and omit.tstart >= term.tstop:
+            return False
+    if omit.tstop is not None:
+        if term.tstop is not None and omit.tstop > term.tstop:
+            return False
+        if term.tstart is not None and omit.tstop <= term.tstart:
+            return False
+    return True
+
+
+def _window_complement(term: Term, omit: Term) -> list[Term]:
+    """Terms covering the part of ``term``'s lag window that ``omit`` does not cover (0, 1 or 2 terms)"""
+    out = []
+    if omit.tstart is not None and (term.tstart is None or omit.tstart > term.tstart):
+        out.append(replace(term, tstop=omit.tstart))
+    if omit.tstop is not None and (term.tstop is None or omit.tstop < term.tstop):
+        out.append(replace(term, tstart=omit.tstop))
+    return out
+
+
 def _expand_term(
         term: Term,
         named_models: dict[str, Model],
@@ -163,6 +199,14 @@ class Model:
         duplicates = [term for term, count in counts.items() if count > 1]
         if duplicates:
             raise TRFModelError(f"{self.name}: duplicate terms {', '.join(duplicates)}")
+        by_base = {}
+        for term in self.terms:
+            by_base.setdefault((term.stimulus, term.code), []).append(term)
+        for terms in by_base.values():
+            for i, term in enumerate(terms):
+                for other in terms[i + 1:]:
+                    if _windows_overlap(term, other):
+                        raise TRFModelError(f"{self.name}: overlapping lag windows {term.string} and {other.string}")
 
     @cached_property
     def name(self) -> str:
@@ -210,10 +254,24 @@ class Model:
         return Model(self.terms + other.terms)
 
     def __sub__(self, other: Model) -> Model:
-        if not all(term in self.terms for term in other.terms):
-            missing = [term.string for term in other.terms if term not in self.terms]
-            raise ValueError(f"{self.name} - {other.name}:\nMissing terms: {', '.join(missing)}")
-        return Model(tuple([term for term in self.terms if term not in other.terms]))
+        """Remove terms; a term with a lag window removes that window from the matching term, keeping the complement"""
+        terms = list(self.terms)
+        for omit in other.terms:
+            candidates = [term for term in terms if term.stimulus == omit.stimulus and term.code == omit.code]
+            if not candidates:
+                raise TRFModelError(f"{self.name} - {other.name}: no term matching {omit.string}")
+            if omit.tstart is None and omit.tstop is None:
+                for term in candidates:
+                    terms.remove(term)
+                continue
+            containing = [term for term in candidates if _window_contains(term, omit)]
+            if not containing:
+                raise TRFModelError(f"{self.name} - {other.name}: lag window of {omit.string} is not contained in any single term ({', '.join(term.string for term in candidates)})")
+            elif len(containing) > 1:
+                raise TRFModelError(f"{self.name} - {other.name}: lag window of {omit.string} is ambiguous (contained in {', '.join(term.string for term in containing)})")
+            index = terms.index(containing[0])
+            terms[index:index + 1] = _window_complement(containing[0], omit)
+        return Model(tuple(terms))
 
     def __hash__(self):
         return hash(self.name)
@@ -291,12 +349,7 @@ class ModelExpression:
         base = self.base.initialize(named_models)
         if not self.subtract:
             return base
-        # remove subtraction
-        terms = list(base.terms)
-        subtract = _expand_term(self.subtract, named_models)
-        for term_i in subtract:
-            terms.remove(term_i)
-        return Model(tuple(terms))
+        return base - Model(_expand_term(self.subtract, named_models))
 
 
 def model_comparison_table(x1: Model, x0: Model, x1_name: str = 'x1', x0_name: str = 'x0'):

--- a/eelbrain/_experiment/trf/model.py
+++ b/eelbrain/_experiment/trf/model.py
@@ -308,6 +308,10 @@ class Model:
             containing = next((term for term in candidates if _window_contains(term, omit)), None)
             if containing is None:
                 raise TRFModelError(f"{self.name} - {other.name}: lag window of {omit.string} is not contained in any single term ({', '.join(term.string for term in candidates)})")
+            # an open omit bound inherits the containing term's bound, which must not silently exclude another piece of a split predictor
+            straddled = [term for term in candidates if term is not containing and _windows_overlap(term, omit)]
+            if straddled:
+                raise TRFModelError(f"{self.name} - {other.name}: lag window of {omit.string} overlaps {', '.join(term.string for term in straddled)} in addition to {containing.string}; make the omitted window explicit")
             index = terms.index(containing)
             terms[index:index + 1] = _window_complement(containing, omit)
         return Model(tuple(terms))
@@ -325,7 +329,7 @@ class Model:
             named_models: dict[str, Model] = {},
     ) -> Model:
         if isinstance(x, cls):
-            return x
+            model = x
         elif isinstance(x, str):
             model = cls.from_string(x)
         elif isinstance(x, Sequence):
@@ -360,8 +364,10 @@ class Model:
         return Model(tuple(terms))
 
     def initialize(self, named_models: dict[str, Model]) -> Model:
-        terms = list(chain.from_iterable(_expand_term(term, named_models) for term in self.terms))
-        return Model(tuple(terms))
+        terms = tuple(chain.from_iterable(_expand_term(term, named_models) for term in self.terms))
+        if terms == self.terms:
+            return self
+        return Model(terms)
 
     def term_table(self) -> fmtxt.Table:
         show_stimulus = any(term.stimulus for term in self.terms)
@@ -562,7 +568,7 @@ class Comparison:
     x0: Model
     tail: int = 1
     public_name: str = None
-    # Construction record of an omit comparison, needed because omitted terms treat bounds differently; Example: 'a + b @ b[0.6:]' with tstart=0, tstop=0.5 -> x1 = 'a + b[:0.6]'
+    # Construction record of an omit comparison, needed because omitted terms treat bounds differently; Example: 'a + b @ b[0.6:]' with tstart=0, tstop=0.5 -> x1 = 'a + b[:0.6]'. Cleared by resolve_lags: once every bound is explicit the record has no further job. omits[i] is subtracted from omit_base to produce models[i] (x1, x0).
     omit_base: Model = field(default=None, compare=False)
     omits: tuple[Model | None, Model | None] = field(default=(None, None), compare=False)
 
@@ -643,7 +649,8 @@ class Comparison:
             x1, x0 = (base if omit is None else base - omit for omit in self.omits)
         if x1 == self.x1 and x0 == self.x0:
             return self
-        return replace(self, x1=x1, x0=x0)
+        # With every bound explicit the record has no further job; clearing it keeps re-resolution independent of the original model-wide bounds
+        return replace(self, x1=x1, x0=x0, omit_base=None, omits=(None, None))
 
     def normalize_lags(
             self,

--- a/eelbrain/_experiment/trf/nodes.py
+++ b/eelbrain/_experiment/trf/nodes.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from dataclasses import dataclass, asdict
 from itertools import repeat
 from pathlib import Path
@@ -43,7 +44,7 @@ class Recording:
         suffix = f'task-{self.task}'
         if self.run:
             suffix += f'_run-{self.run}'
-        return f'{term.string}@{suffix}'
+        return f'{term.without_lags().string}@{suffix}'
 
 
 def find_bids_recordings(ds: Dataset) -> list[Recording]:
@@ -137,7 +138,7 @@ class PredictorInput(VersionedInput[NDVar]):
     """
     name = 'predictor'
     key_options = {
-        'term': OptionSpec(None, Term, normalize=Term._coerce),
+        'term': OptionSpec(None, Term, normalize=Term._coerce_and_strip_lags),
     }
 
     def __init__(
@@ -262,6 +263,9 @@ class TRFDerivative(Derivative[object]):
     def fingerprint(self, ctx: Request) -> dict[str, object]:
         return {'estimator': self.estimators[ctx.options['estimator']]}
 
+    def validate_options(self, ctx: Request) -> None:
+        ctx.options['x'].validate_lags(ctx.options['tstart'], ctx.options['tstop'])
+
     def dependencies(self, ctx: Request) -> tuple[Dependency, ...]:
         est = self.estimators[ctx.options['estimator']]
 
@@ -297,13 +301,12 @@ class TRFDerivative(Derivative[object]):
                 options = ctx.options_for('epoch-events', 'samplingrate', 'decim')
                 events = ctx.load('epoch-events', options=options)
                 nested = events.info.get('nested_events')
-            file_term = term.without_lags()  # lag overrides do not affect the predictor file
             if isinstance(predictor, SubjectUTSPredictor) and not predictor.per_event:
                 if recordings is None:
                     recordings = find_bids_recordings(events)
                 for recording in dict.fromkeys(recordings):  # ordered set
-                    label = recording.dependency_label(file_term)
-                    edges[label] = Dependency('predictor', label=label, state=asdict(recording), options={'term': file_term})
+                    label = recording.dependency_label(term)
+                    edges[label] = Dependency('predictor', label=label, state=asdict(recording), options={'term': term})
                 continue
             elif nested:
                 stims = {stim for i in range(events.n_cases) for stim in events[i, nested][stim_var].cells}
@@ -312,8 +315,8 @@ class TRFDerivative(Derivative[object]):
             else:
                 raise TRFModelError(f"{term.string}: stimulus variable {stim_var!r} not in the events")
             for stim in stims:
-                stim_term = file_term.with_stimulus(stim)
-                edges[stim_term.string] = Dependency('predictor', label=stim_term.string, options={'term': stim_term})
+                label = term.file_label(stim)
+                edges[label] = Dependency('predictor', label=label, options={'term': term.with_stimulus(stim)})
         deps.extend(edges.values())
         return tuple(deps)
 
@@ -340,13 +343,16 @@ class TRFDerivative(Derivative[object]):
             tstop = ctx.options['tstop']
             if any(term.tstart is not None or term.tstop is not None for term in model.terms):
                 # per-term lag windows: the estimators accept one (tstart, tstop) per predictor
-                tstart = [ctx.options['tstart'] if term.tstart is None else term.tstart for term in model.terms]
-                tstop = [ctx.options['tstop'] if term.tstop is None else term.tstop for term in model.terms]
+                resolved = [term.with_default_lags(tstart, tstop) for term in model.terms]
+                tstart = [term.tstart for term in resolved]
+                tstop = [term.tstop for term in resolved]
                 if len(model.terms) == 1:  # a single x is passed to the estimator outside a list
                     tstart, tstop = tstart[0], tstop[0]
             ds = ctx.load('response')
             y = ds[ctx.options['data'].response_key(ds)]
-            xs = [self._load_predictor(ctx, ds, term, y) for term in model.terms]
+            # name predictors by the bare term; the lag window disambiguates a predictor that occurs with several windows
+            base_counts = Counter((term.stimulus, term.code) for term in model.terms)
+            xs = [self._load_predictor(ctx, ds, term, y, term.string if base_counts[term.stimulus, term.code] > 1 else term.without_lags().string) for term in model.terms]
             fwd = cov = None
             if 'fwd' in est.extra_inputs:
                 fwd = ctx.load('fwd')  # ensure built and tracked as a dependency
@@ -355,8 +361,8 @@ class TRFDerivative(Derivative[object]):
                 cov = ctx.load('cov')
         return TRFJob(est, y, xs, tstart, tstop, fwd, cov)
 
-    def _load_predictor(self, ctx: Request, ds, term: Term, y) -> NDVar | Datalist:
-        "Assemble one model term's predictor, shaped to the response time axis"
+    def _load_predictor(self, ctx: Request, ds, term: Term, y, name: str) -> NDVar | Datalist:
+        "Assemble one model term's predictor, shaped to the response time axis and named ``name``"
         predictor, stim_var = self._term_predictor(term)
         is_variable_time = isinstance(y, Datalist)
         is_nested = ds.info.get('nested_events')  # 'events' for a ContinuousEpoch
@@ -366,54 +372,54 @@ class TRFDerivative(Derivative[object]):
             if filter_x:
                 raise ValueError(f"filter_x: not available for {type(predictor).__name__}")
             if is_nested:
-                return Datalist([predictor._generate_continuous(yi.time, ds[i, is_nested], term) for i, yi in enumerate(y)])
+                return Datalist([predictor._generate_continuous(yi.time, ds[i, is_nested], term, name) for i, yi in enumerate(y)], name=name)
             if is_variable_time:
                 raise NotImplementedError(f"{type(predictor).__name__} for variable-length epochs")
-            return predictor._generate(y.time, ds, term)
+            return predictor._generate(y.time, ds, term, name)
         elif not isinstance(predictor, (UTSPredictor, NUTSPredictor)):
             raise NotImplementedError(f"{term.string}: loading {type(predictor).__name__} is not supported")
 
         # per-subject sequence predictor: one recording-long file, cut per case
         if isinstance(predictor, SubjectUTSPredictor) and not predictor.per_event:
-            return self._load_subject_predictor(ctx, predictor, term, ds, y, filter_x, is_nested)
+            return self._load_subject_predictor(ctx, predictor, term, ds, y, filter_x, is_nested, name)
 
         if stim_var not in ds:
             raise TRFModelError(f"{term.string}: stimulus variable {stim_var!r} not in the data")
 
         if is_nested:
-            return self._load_predictor_nested(ctx, predictor, term, stim_var, ds, y, is_nested, filter_x)
+            return self._load_predictor_nested(ctx, predictor, term, stim_var, ds, y, is_nested, filter_x, name)
 
         # single-event epoch: one stimulus per case, aligned to the response
         stim_factor = ds[stim_var]
         if is_variable_time:
-            xs = [self._aligned_predictor(ctx, predictor, term, s, yi.time, filter_x) for s, yi in zip(stim_factor, y)]
-            return Datalist(xs)
+            xs = [self._aligned_predictor(ctx, predictor, term, s, yi.time, filter_x, name) for s, yi in zip(stim_factor, y)]
+            return Datalist(xs, name=name)
         time = y.time
-        cache = {s: self._aligned_predictor(ctx, predictor, term, s, time, filter_x) for s in stim_factor.cells}
+        cache = {s: self._aligned_predictor(ctx, predictor, term, s, time, filter_x, name) for s in stim_factor.cells}
         x = combine([cache[s] for s in stim_factor])
-        x.name = term.string
+        x.name = name
         return x
 
-    def _load_predictor_nested(self, ctx: Request, predictor: UTSPredictor | NUTSPredictor, term: Term, stim_var: str, ds, y: Datalist, nested: str, filter_x: bool | str) -> Datalist:
+    def _load_predictor_nested(self, ctx: Request, predictor: UTSPredictor | NUTSPredictor, term: Term, stim_var: str, ds, y: Datalist, nested: str, filter_x: bool | str, name: str) -> Datalist:
         "Assemble a per-event (ContinuousEpoch) predictor on the shared ``epoch_time`` axis"
         tstep = y[0].time.tstep
         stims = {stim for i in range(ds.n_cases) for stim in ds[i, nested][stim_var].cells}
-        cache = {stim: predictor._prepare_stimulus(ctx.load(term.without_lags().with_stimulus(stim).string), tstep) for stim in stims}
+        cache = {stim: predictor._prepare_stimulus(ctx.load(term.file_label(stim)), tstep) for stim in stims}
         xs = []
         for i, yi in enumerate(y):
             x = predictor._generate_continuous(yi.time, ds[i, nested], stim_var, term, cache)
             x = filter_predictor(x, self.raw, ctx.state['raw'], filter_x)
-            x.name = term.string
+            x.name = name
             xs.append(x)
-        return Datalist(xs, name=term.string)
+        return Datalist(xs, name=name)
 
-    def _load_subject_predictor(self, ctx: Request, predictor: SubjectUTSPredictor, term: Term, ds, y, filter_x: bool | str, is_nested: bool) -> NDVar | Datalist:
+    def _load_subject_predictor(self, ctx: Request, predictor: SubjectUTSPredictor, term: Term, ds, y, filter_x: bool | str, is_nested: bool, name: str) -> NDVar | Datalist:
         "Cut recording-long predictors into response cases"
         times = [yi.time for yi in y] if isinstance(y, Datalist) else [y.time] * ds.n_cases
         recordings = find_bids_recordings(ds)
         x_fulls = {}
         for recording in set(recordings):
-            label = recording.dependency_label(term.without_lags())
+            label = recording.dependency_label(term)
             x_full = predictor._prepare_sequence(ctx.load(label), times[0].tstep, term)
             x_fulls[recording] = filter_predictor(x_full, self.raw, ctx.state['raw'], filter_x)
 
@@ -432,23 +438,23 @@ class TRFDerivative(Derivative[object]):
             offset = x_full.time.tstep * round(offset / x_full.time.tstep)  # snap to the predictor's sample grid
             x = set_tmin(x_full, x_full.time.tmin - offset) if offset else x_full  # global time offset -> local 0
             x = pad(x, time.tmin, nsamples=time.nsamples, set_tmin=True)  # crop to the segment
-            x.name = term.string
+            x.name = name
             return x
 
         xs = [chunk(time, recording, offset) for time, recording, offset in zip(times, recordings, offsets)]
         if isinstance(y, Datalist):
-            return Datalist(xs)
+            return Datalist(xs, name=name)
         x = combine(xs)
-        x.name = term.string
+        x.name = name
         return x
 
-    def _aligned_predictor(self, ctx: Request, predictor: UTSPredictor | NUTSPredictor, term: Term, stim: str | None, time, filter_x: bool | str) -> NDVar:
+    def _aligned_predictor(self, ctx: Request, predictor: UTSPredictor | NUTSPredictor, term: Term, stim: str | None, time, filter_x: bool | str, name: str) -> NDVar:
         "Build one stimulus' predictor from its file data and align it to ``time``"
-        subset = ctx.load(term.without_lags().with_stimulus(stim).string)
+        subset = ctx.load(term.file_label(stim))
         x = predictor._generate(subset, None, time.tstep, None, term)
         x = filter_predictor(x, self.raw, ctx.state['raw'], filter_x)
         x = pad(x, time.tmin, nsamples=time.nsamples, set_tmin=True)
-        x.name = term.string
+        x.name = name
         return x
 
     def save(self, ctx: Request, path: Path, value: object) -> None:
@@ -708,6 +714,7 @@ class TRFModelTestDerivative(Derivative[Any]):
         return tuple(fields)
 
     def validate_options(self, ctx: Request) -> None:
+        ctx.options['x'].validate_lags(ctx.options['tstart'], ctx.options['tstop'])
         metric, pmin, samples = ctx.options['metric'], ctx.options['pmin'], ctx.options['samples']
         _, reducer = self._metric_parts(metric)
         # A reducer always leaves one value per case; that an unreduced metric is already univariate only the data shows (checked in _test_data)

--- a/eelbrain/_experiment/trf/nodes.py
+++ b/eelbrain/_experiment/trf/nodes.py
@@ -194,6 +194,14 @@ class PredictorInput(VersionedInput[NDVar]):
         return predictor._relevant_data(contents, term)
 
 
+def _normalize_trf_options(options: dict) -> None:
+    """Canonicalize the ``(x, tstart, tstop)`` options in place (see :meth:`Model.normalize_lags`), so that equivalent spellings share one cache key"""
+    if options['x'] is None:
+        return
+    x, tstart, tstop = options['x'].normalize_lags(options['tstart'], options['tstop'])
+    options.update(x=x.sorted(), tstart=tstart, tstop=tstop)
+
+
 class TRFDerivative(Derivative[object]):
     """Fit and cache a TRF for one subject
 
@@ -264,7 +272,7 @@ class TRFDerivative(Derivative[object]):
         return {'estimator': self.estimators[ctx.options['estimator']]}
 
     def validate_options(self, ctx: Request) -> None:
-        ctx.options['x'].validate_lags(ctx.options['tstart'], ctx.options['tstop'])
+        _normalize_trf_options(ctx.options)
 
     def dependencies(self, ctx: Request) -> tuple[Dependency, ...]:
         est = self.estimators[ctx.options['estimator']]
@@ -341,18 +349,23 @@ class TRFDerivative(Derivative[object]):
                 raise TRFModelError(f"{ctx.options['x']!r}: empty model")
             tstart = ctx.options['tstart']
             tstop = ctx.options['tstop']
-            if any(term.tstart is not None or term.tstop is not None for term in model.terms):
-                # per-term lag windows: the estimators accept one (tstart, tstop) per predictor
-                resolved = [term.with_default_lags(tstart, tstop) for term in model.terms]
-                tstart = [term.tstart for term in resolved]
-                tstop = [term.tstop for term in resolved]
-                if len(model.terms) == 1:  # a single x is passed to the estimator outside a list
-                    tstart, tstop = tstart[0], tstop[0]
+            if tstart is None:
+                # canonical per-term lag windows (see Model.normalize_lags): every term carries explicit bounds; the estimators accept one (tstart, tstop) per predictor
+                tstart = [term.tstart for term in model.terms]
+                tstop = [term.tstop for term in model.terms]
             ds = ctx.load('response')
             y = ds[ctx.options['data'].response_key(ds)]
             # name predictors by the bare term; the lag window disambiguates a predictor that occurs with several windows
             base_counts = Counter((term.stimulus, term.code) for term in model.terms)
-            xs = [self._load_predictor(ctx, ds, term, y, term.string if base_counts[term.stimulus, term.code] > 1 else term.without_lags().string) for term in model.terms]
+            xs = []
+            for term in model.terms:
+                x = self._load_predictor(ctx, ds, term, y)
+                name = term.string if base_counts[term.stimulus, term.code] > 1 else term.without_lags().string
+                if isinstance(x, Datalist):
+                    for xi in x:
+                        xi.name = name
+                x.name = name
+                xs.append(x)
             fwd = cov = None
             if 'fwd' in est.extra_inputs:
                 fwd = ctx.load('fwd')  # ensure built and tracked as a dependency
@@ -361,8 +374,8 @@ class TRFDerivative(Derivative[object]):
                 cov = ctx.load('cov')
         return TRFJob(est, y, xs, tstart, tstop, fwd, cov)
 
-    def _load_predictor(self, ctx: Request, ds, term: Term, y, name: str) -> NDVar | Datalist:
-        "Assemble one model term's predictor, shaped to the response time axis and named ``name``"
+    def _load_predictor(self, ctx: Request, ds, term: Term, y) -> NDVar | Datalist:
+        "Assemble one model term's predictor, shaped to the response time axis"
         predictor, stim_var = self._term_predictor(term)
         is_variable_time = isinstance(y, Datalist)
         is_nested = ds.info.get('nested_events')  # 'events' for a ContinuousEpoch
@@ -372,35 +385,33 @@ class TRFDerivative(Derivative[object]):
             if filter_x:
                 raise ValueError(f"filter_x: not available for {type(predictor).__name__}")
             if is_nested:
-                return Datalist([predictor._generate_continuous(yi.time, ds[i, is_nested], term, name) for i, yi in enumerate(y)], name=name)
+                return Datalist([predictor._generate_continuous(yi.time, ds[i, is_nested], term) for i, yi in enumerate(y)])
             if is_variable_time:
                 raise NotImplementedError(f"{type(predictor).__name__} for variable-length epochs")
-            return predictor._generate(y.time, ds, term, name)
+            return predictor._generate(y.time, ds, term)
         elif not isinstance(predictor, (UTSPredictor, NUTSPredictor)):
             raise NotImplementedError(f"{term.string}: loading {type(predictor).__name__} is not supported")
 
         # per-subject sequence predictor: one recording-long file, cut per case
         if isinstance(predictor, SubjectUTSPredictor) and not predictor.per_event:
-            return self._load_subject_predictor(ctx, predictor, term, ds, y, filter_x, is_nested, name)
+            return self._load_subject_predictor(ctx, predictor, term, ds, y, filter_x, is_nested)
 
         if stim_var not in ds:
             raise TRFModelError(f"{term.string}: stimulus variable {stim_var!r} not in the data")
 
         if is_nested:
-            return self._load_predictor_nested(ctx, predictor, term, stim_var, ds, y, is_nested, filter_x, name)
+            return self._load_predictor_nested(ctx, predictor, term, stim_var, ds, y, is_nested, filter_x)
 
         # single-event epoch: one stimulus per case, aligned to the response
         stim_factor = ds[stim_var]
         if is_variable_time:
-            xs = [self._aligned_predictor(ctx, predictor, term, s, yi.time, filter_x, name) for s, yi in zip(stim_factor, y)]
-            return Datalist(xs, name=name)
+            xs = [self._aligned_predictor(ctx, predictor, term, s, yi.time, filter_x) for s, yi in zip(stim_factor, y)]
+            return Datalist(xs)
         time = y.time
-        cache = {s: self._aligned_predictor(ctx, predictor, term, s, time, filter_x, name) for s in stim_factor.cells}
-        x = combine([cache[s] for s in stim_factor])
-        x.name = name
-        return x
+        cache = {s: self._aligned_predictor(ctx, predictor, term, s, time, filter_x) for s in stim_factor.cells}
+        return combine([cache[s] for s in stim_factor])
 
-    def _load_predictor_nested(self, ctx: Request, predictor: UTSPredictor | NUTSPredictor, term: Term, stim_var: str, ds, y: Datalist, nested: str, filter_x: bool | str, name: str) -> Datalist:
+    def _load_predictor_nested(self, ctx: Request, predictor: UTSPredictor | NUTSPredictor, term: Term, stim_var: str, ds, y: Datalist, nested: str, filter_x: bool | str) -> Datalist:
         "Assemble a per-event (ContinuousEpoch) predictor on the shared ``epoch_time`` axis"
         tstep = y[0].time.tstep
         stims = {stim for i in range(ds.n_cases) for stim in ds[i, nested][stim_var].cells}
@@ -408,12 +419,10 @@ class TRFDerivative(Derivative[object]):
         xs = []
         for i, yi in enumerate(y):
             x = predictor._generate_continuous(yi.time, ds[i, nested], stim_var, term, cache)
-            x = filter_predictor(x, self.raw, ctx.state['raw'], filter_x)
-            x.name = name
-            xs.append(x)
-        return Datalist(xs, name=name)
+            xs.append(filter_predictor(x, self.raw, ctx.state['raw'], filter_x))
+        return Datalist(xs)
 
-    def _load_subject_predictor(self, ctx: Request, predictor: SubjectUTSPredictor, term: Term, ds, y, filter_x: bool | str, is_nested: bool, name: str) -> NDVar | Datalist:
+    def _load_subject_predictor(self, ctx: Request, predictor: SubjectUTSPredictor, term: Term, ds, y, filter_x: bool | str, is_nested: bool) -> NDVar | Datalist:
         "Cut recording-long predictors into response cases"
         times = [yi.time for yi in y] if isinstance(y, Datalist) else [y.time] * ds.n_cases
         recordings = find_bids_recordings(ds)
@@ -437,25 +446,19 @@ class TRFDerivative(Derivative[object]):
             x_full = x_fulls[recording]
             offset = x_full.time.tstep * round(offset / x_full.time.tstep)  # snap to the predictor's sample grid
             x = set_tmin(x_full, x_full.time.tmin - offset) if offset else x_full  # global time offset -> local 0
-            x = pad(x, time.tmin, nsamples=time.nsamples, set_tmin=True)  # crop to the segment
-            x.name = name
-            return x
+            return pad(x, time.tmin, nsamples=time.nsamples, set_tmin=True)  # crop to the segment
 
         xs = [chunk(time, recording, offset) for time, recording, offset in zip(times, recordings, offsets)]
         if isinstance(y, Datalist):
-            return Datalist(xs, name=name)
-        x = combine(xs)
-        x.name = name
-        return x
+            return Datalist(xs)
+        return combine(xs)
 
-    def _aligned_predictor(self, ctx: Request, predictor: UTSPredictor | NUTSPredictor, term: Term, stim: str | None, time, filter_x: bool | str, name: str) -> NDVar:
+    def _aligned_predictor(self, ctx: Request, predictor: UTSPredictor | NUTSPredictor, term: Term, stim: str | None, time, filter_x: bool | str) -> NDVar:
         "Build one stimulus' predictor from its file data and align it to ``time``"
         subset = ctx.load(term.file_label(stim))
         x = predictor._generate(subset, None, time.tstep, None, term)
         x = filter_predictor(x, self.raw, ctx.state['raw'], filter_x)
-        x = pad(x, time.tmin, nsamples=time.nsamples, set_tmin=True)
-        x.name = name
-        return x
+        return pad(x, time.tmin, nsamples=time.nsamples, set_tmin=True)
 
     def save(self, ctx: Request, path: Path, value: object) -> None:
         save.pickle(value, path)
@@ -518,6 +521,7 @@ class TRFDatasetDerivative(UncachedDerivative[Dataset]):
         return tuple(fields)
 
     def validate_options(self, ctx: Request) -> None:
+        _normalize_trf_options(ctx.options)
         if not ctx.state['inv'] and (smooth := ctx.options['smooth']):
             raise ValueError(f"{smooth=}: smoothing is only available for source-space data")
 
@@ -627,6 +631,7 @@ class TRFGroupDatasetDerivative(UncachedDerivative[Dataset]):
         return ctx.options_for('trf-dataset', *subject_options, smooth=None)
 
     def validate_options(self, ctx: Request) -> None:
+        _normalize_trf_options(ctx.options)
         if not ctx.state['inv'] and (smooth := ctx.options['smooth']):
             raise ValueError(f"{smooth=}: smoothing is only available for source-space data")
 
@@ -714,7 +719,7 @@ class TRFModelTestDerivative(Derivative[Any]):
         return tuple(fields)
 
     def validate_options(self, ctx: Request) -> None:
-        ctx.options['x'].validate_lags(ctx.options['tstart'], ctx.options['tstop'])
+        _normalize_trf_options(ctx.options)
         metric, pmin, samples = ctx.options['metric'], ctx.options['pmin'], ctx.options['samples']
         _, reducer = self._metric_parts(metric)
         # A reducer always leaves one value per case; that an unreduced metric is already univariate only the data shows (checked in _test_data)

--- a/eelbrain/_experiment/trf/nodes.py
+++ b/eelbrain/_experiment/trf/nodes.py
@@ -138,7 +138,7 @@ class PredictorInput(VersionedInput[NDVar]):
     """
     name = 'predictor'
     key_options = {
-        'term': OptionSpec(None, Term, normalize=Term._coerce_and_strip_lags),
+        'term': OptionSpec(None, Term, normalize=lambda x: Term._coerce(x).without_lags()),
     }
 
     def __init__(

--- a/eelbrain/_experiment/trf/nodes.py
+++ b/eelbrain/_experiment/trf/nodes.py
@@ -297,12 +297,13 @@ class TRFDerivative(Derivative[object]):
                 options = ctx.options_for('epoch-events', 'samplingrate', 'decim')
                 events = ctx.load('epoch-events', options=options)
                 nested = events.info.get('nested_events')
+            file_term = term.without_lags()  # lag overrides do not affect the predictor file
             if isinstance(predictor, SubjectUTSPredictor) and not predictor.per_event:
                 if recordings is None:
                     recordings = find_bids_recordings(events)
                 for recording in dict.fromkeys(recordings):  # ordered set
-                    label = recording.dependency_label(term)
-                    edges[label] = Dependency('predictor', label=label, state=asdict(recording), options={'term': term})
+                    label = recording.dependency_label(file_term)
+                    edges[label] = Dependency('predictor', label=label, state=asdict(recording), options={'term': file_term})
                 continue
             elif nested:
                 stims = {stim for i in range(events.n_cases) for stim in events[i, nested][stim_var].cells}
@@ -311,7 +312,7 @@ class TRFDerivative(Derivative[object]):
             else:
                 raise TRFModelError(f"{term.string}: stimulus variable {stim_var!r} not in the events")
             for stim in stims:
-                stim_term = term.with_stimulus(stim)
+                stim_term = file_term.with_stimulus(stim)
                 edges[stim_term.string] = Dependency('predictor', label=stim_term.string, options={'term': stim_term})
         deps.extend(edges.values())
         return tuple(deps)
@@ -337,6 +338,12 @@ class TRFDerivative(Derivative[object]):
                 raise TRFModelError(f"{ctx.options['x']!r}: empty model")
             tstart = ctx.options['tstart']
             tstop = ctx.options['tstop']
+            if any(term.tstart is not None or term.tstop is not None for term in model.terms):
+                # per-term lag windows: the estimators accept one (tstart, tstop) per predictor
+                tstart = [ctx.options['tstart'] if term.tstart is None else term.tstart for term in model.terms]
+                tstop = [ctx.options['tstop'] if term.tstop is None else term.tstop for term in model.terms]
+                if len(model.terms) == 1:  # a single x is passed to the estimator outside a list
+                    tstart, tstop = tstart[0], tstop[0]
             ds = ctx.load('response')
             y = ds[ctx.options['data'].response_key(ds)]
             xs = [self._load_predictor(ctx, ds, term, y) for term in model.terms]
@@ -391,7 +398,7 @@ class TRFDerivative(Derivative[object]):
         "Assemble a per-event (ContinuousEpoch) predictor on the shared ``epoch_time`` axis"
         tstep = y[0].time.tstep
         stims = {stim for i in range(ds.n_cases) for stim in ds[i, nested][stim_var].cells}
-        cache = {stim: predictor._prepare_stimulus(ctx.load(term.with_stimulus(stim).string), tstep) for stim in stims}
+        cache = {stim: predictor._prepare_stimulus(ctx.load(term.without_lags().with_stimulus(stim).string), tstep) for stim in stims}
         xs = []
         for i, yi in enumerate(y):
             x = predictor._generate_continuous(yi.time, ds[i, nested], stim_var, term, cache)
@@ -406,7 +413,7 @@ class TRFDerivative(Derivative[object]):
         recordings = find_bids_recordings(ds)
         x_fulls = {}
         for recording in set(recordings):
-            label = recording.dependency_label(term)
+            label = recording.dependency_label(term.without_lags())
             x_full = predictor._prepare_sequence(ctx.load(label), times[0].tstep, term)
             x_fulls[recording] = filter_predictor(x_full, self.raw, ctx.state['raw'], filter_x)
 
@@ -437,8 +444,7 @@ class TRFDerivative(Derivative[object]):
 
     def _aligned_predictor(self, ctx: Request, predictor: UTSPredictor | NUTSPredictor, term: Term, stim: str | None, time, filter_x: bool | str) -> NDVar:
         "Build one stimulus' predictor from its file data and align it to ``time``"
-        stim_term = term.with_stimulus(stim)
-        subset = ctx.load(stim_term.string)
+        subset = ctx.load(term.without_lags().with_stimulus(stim).string)
         x = predictor._generate(subset, None, time.tstep, None, term)
         x = filter_predictor(x, self.raw, ctx.state['raw'], filter_x)
         x = pad(x, time.tmin, nsamples=time.nsamples, set_tmin=True)

--- a/eelbrain/_experiment/trf/predictor.py
+++ b/eelbrain/_experiment/trf/predictor.py
@@ -60,18 +60,18 @@ class EventPredictor(Configuration):
         self.latency = typed_arg(latency, float, str)
         self.sel = typed_arg(sel, str)
 
-    def _generate(self, uts: UTS, ds: Dataset, term: Term):
+    def _generate(self, uts: UTS, ds: Dataset, term: Term, name: str) -> NDVar:
         assert term.stimulus is None
         if self.sel:
             raise NotImplementedError
-        return epoch_impulse_predictor((ds.n_cases, uts), self.value, self.latency, term.string, ds)
+        return epoch_impulse_predictor((ds.n_cases, uts), self.value, self.latency, name, ds)
 
-    def _generate_continuous(self, uts: UTS, events: Dataset, term: Term) -> NDVar:
+    def _generate_continuous(self, uts: UTS, events: Dataset, term: Term, name: str) -> NDVar:
         "Impulse for each event in one ContinuousEpoch segment, placed at ``epoch_time``"
         assert term.stimulus is None
         if self.sel:
             events = events.sub(self.sel)
-        return event_impulse_predictor(uts, 'epoch_time', self.value, self.latency, term.code, events)
+        return event_impulse_predictor(uts, 'epoch_time', self.value, self.latency, name, events)
 
 
 class FilePredictorBase(Configuration):

--- a/eelbrain/_experiment/trf/predictor.py
+++ b/eelbrain/_experiment/trf/predictor.py
@@ -60,18 +60,18 @@ class EventPredictor(Configuration):
         self.latency = typed_arg(latency, float, str)
         self.sel = typed_arg(sel, str)
 
-    def _generate(self, uts: UTS, ds: Dataset, term: Term, name: str) -> NDVar:
+    def _generate(self, uts: UTS, ds: Dataset, term: Term) -> NDVar:
         assert term.stimulus is None
         if self.sel:
             raise NotImplementedError
-        return epoch_impulse_predictor((ds.n_cases, uts), self.value, self.latency, name, ds)
+        return epoch_impulse_predictor((ds.n_cases, uts), self.value, self.latency, term.string, ds)
 
-    def _generate_continuous(self, uts: UTS, events: Dataset, term: Term, name: str) -> NDVar:
+    def _generate_continuous(self, uts: UTS, events: Dataset, term: Term) -> NDVar:
         "Impulse for each event in one ContinuousEpoch segment, placed at ``epoch_time``"
         assert term.stimulus is None
         if self.sel:
             events = events.sub(self.sel)
-        return event_impulse_predictor(uts, 'epoch_time', self.value, self.latency, name, events)
+        return event_impulse_predictor(uts, 'epoch_time', self.value, self.latency, term.code, events)
 
 
 class FilePredictorBase(Configuration):

--- a/eelbrain/_experiment/trf/tests/test_model.py
+++ b/eelbrain/_experiment/trf/tests/test_model.py
@@ -107,6 +107,12 @@ def test_term_lags():
     comparison = Comparison.coerce('x + gammatone[0.2:] > x')
     assert comparison.x1_only.name == 'gammatone[0.2:]'
 
+    # a Term instance passed as a predictor-node option is stripped like a string spelling (the predictor file is lag-independent)
+    from eelbrain._experiment.trf.nodes import PredictorInput
+    spec = PredictorInput.key_options['term']
+    assert spec.validated(None, 'term', parse_term('gammatone[0.2:0.4]')) == parse_term('gammatone')
+    assert spec.validated(None, 'term', 'gammatone[0.2:0.4]') == parse_term('gammatone')
+
 
 def test_named_model_lags():
     # lag overrides distribute to member terms; explicit member lags take precedence
@@ -174,6 +180,10 @@ def test_comparison_lags():
         Comparison.coerce('a + b[:1] @ b[1:2]')
     with pytest.raises(TRFModelError):  # window straddles a split
         Comparison.coerce('a + b[:1] + b[1:] @ b[0.5:1.5]')
+    with pytest.raises(TRFModelError):  # open omit bound extends into another piece
+        Comparison.coerce('a + b[:1] + b[1:2] @ b[0.5:]')
+    with pytest.raises(TRFModelError):
+        Model.coerce('a + b[:1] + b[1:2]') - Model.coerce('b[0.5:]')
     with pytest.raises(TRFModelError):  # predictor not in model
         Comparison.coerce('a + b @ c[:1]')
     with pytest.raises(TRFModelError):  # add overlapping window
@@ -264,6 +274,7 @@ def test_model_lags_normalization():
     assert comparison.x1.name == 'a[0:0.5] + b[0:0.5]'
     assert comparison.x0.name == 'a[0:0.5] + b[0:0.2]'
     assert tstart is None and tstop is None
+    assert comparison.normalize_lags(tstart, tstop) == (comparison, None, None)  # idempotent (omit record cleared on resolution)
 
 
 def test_term_table_lags():
@@ -291,6 +302,9 @@ def test_model():
     assert xy + z == xyz
     assert xyz - z == xy
     assert xy.intersection(yz) == y
+    # coercing a Model instance expands named models too
+    model = Model.coerce('x-ab + z')
+    assert Model.coerce(model, named_models) == Model.coerce('x-a + x-b + z')
     # duplicate term
     with pytest.raises(TRFModelError):
         Model.coerce("term-1 + term-2 + term-2")

--- a/eelbrain/_experiment/trf/tests/test_model.py
+++ b/eelbrain/_experiment/trf/tests/test_model.py
@@ -78,6 +78,19 @@ def test_term_lags():
     with pytest.raises(TRFModelError):
         parse_term('gammatone[0.5:0.2]')
 
+    # sub-millisecond precision is not supported; bounds snap to the ms grid
+    with pytest.raises(NotImplementedError):
+        parse_term('gammatone[0.0005:0.1]')
+    from eelbrain._experiment.trf.model import Term
+    assert Term(None, 'gammatone', 0.1 + 0.2, 0.5).tstart == 0.3
+
+    # open lag bounds fill in from model-wide defaults
+    assert parse_term('gammatone[0.2:]').with_default_lags(0, 0.5) == parse_term('gammatone[0.2:0.5]')
+    assert parse_term('gammatone[-0.2:]').with_default_lags(0, 0.5) == parse_term('gammatone[-0.2:0.5]')
+    assert parse_term('gammatone').with_default_lags(0, 0.5) == parse_term('gammatone[0:0.5]')
+    with pytest.raises(TRFModelError):  # resolved window is empty
+        parse_term('gammatone[0.6:]').with_default_lags(0, 0.5)
+
     # same predictor with different lag windows
     model = Model.coerce('gammatone[0:0.5] + gammatone[0.5:1]')
     assert model.name == 'gammatone[0:0.5] + gammatone[0.5:1]'
@@ -150,6 +163,13 @@ def test_comparison_lags():
     model = ModelExpression.from_string('ab - b[:1]').initialize(named)
     assert model.name == 'a + b[1:]'
 
+    # difference/intersection decompose lag windows
+    comparison = Comparison.coerce('a + b @ b[:1]')
+    assert comparison.x1_only.name == 'b[:1]'
+    assert not comparison.x0_only
+    assert comparison.common_base.name == 'a + b[1:]'
+    assert comparison.test_term_name == 'b[:1]'
+
     # errors
     with pytest.raises(TRFModelError):  # window not contained in the term's window
         Comparison.coerce('a + b[:1] @ b[1:2]')
@@ -159,6 +179,61 @@ def test_comparison_lags():
         Comparison.coerce('a + b @ c[:1]')
     with pytest.raises(TRFModelError):  # add overlapping window
         Comparison.coerce('a + b +@ b[:1]')
+
+
+def test_comparison_lags_resolved():
+    "Comparison.resolve_lags resolves open bounds against the model-wide tstart/tstop"
+    # omit window beyond the model-wide window: the reduced model would exceed the full model
+    with pytest.raises(TRFModelError):
+        Comparison.coerce('a + b @ b[0.6:]').resolve_lags(0, 0.5)
+    with pytest.raises(TRFModelError):
+        Comparison.coerce('a + b @ b[:0.6]').resolve_lags(0, 0.5)
+    # within the model-wide window: resolution is a no-op
+    comparison = Comparison.coerce('a + b @ b[0.2:]')
+    assert comparison.resolve_lags(0, 0.5) is comparison
+    assert comparison.x0.name == 'a + b[:0.2]'
+    # two-sided omit: each omitted window is checked against the full model
+    Comparison.coerce('a + b @ b[:0.2] > b[0.2:]').resolve_lags(0, 0.5)
+    with pytest.raises(TRFModelError):
+        Comparison.coerce('a + b @ b[:0.2] > b[0.6:]').resolve_lags(0, 0.5)
+    # direct comparisons carry no omitted windows and only require valid models
+    Comparison.coerce('a + b[:0.6] > a').resolve_lags(0, 0.5)
+    # an omit bound at the model-wide bound: the zero-width complement piece is dropped
+    comparison = Comparison.coerce('a + b @ b[0:0.2]')
+    assert comparison.x0.name == 'a + b[:0] + b[0.2:]'
+    resolved = comparison.resolve_lags(0, 0.5)
+    assert resolved.x0.name == 'a + b[0.2:]'
+    assert resolved.name == 'a + b @ b[0:0.2]'  # display name preserved
+
+
+def test_model_lags_validation():
+    "Model.resolve_lags/validate_lags: complete, non-empty windows given model-wide defaults"
+    model = Model.coerce('a + b[0.1:0.4]')
+    assert model.resolve_lags(0, 0.5) is model
+    model.validate_lags(0, 0.5)
+    # term windows beyond the model-wide window are allowed
+    Model.coerce('a + b[0.6:0.8]').validate_lags(0, 0.5)
+    # if all terms specify complete windows, model-wide defaults are not needed
+    Model.coerce('a[0:0.3] + b[0.1:0.4]').validate_lags(None, None)
+    with pytest.raises(TRFModelError):  # no tstart for a
+        Model.coerce('a + b[0.1:0.4]').validate_lags(None, 0.5)
+    with pytest.raises(TRFModelError):  # no tstop for a
+        Model.coerce('a + b[0.1:0.4]').validate_lags(0, None)
+    with pytest.raises(TRFModelError):  # resolved window of b is negative
+        Model.coerce('a + b[0.6:]').resolve_lags(0, 0.5)
+    # a zero-width window covers no lags: dropped by resolve_lags, rejected by validate_lags
+    assert Model.coerce('a + b[0.5:]').resolve_lags(0, 0.5).name == 'a'
+    with pytest.raises(TRFModelError):
+        Model.coerce('a + b[0.5:]').validate_lags(0, 0.5)
+    with pytest.raises(TRFModelError):  # no term covers any lags
+        Model.coerce('b[0.5:]').resolve_lags(0, 0.5)
+
+
+def test_term_table_lags():
+    table = Model.coerce('a + b[0.1:0.4]').term_table()
+    assert str(table).splitlines()[0].split() == ['#', 'Code', 'tstart', 'tstop']
+    table = Model.coerce('a + b').term_table()
+    assert str(table).splitlines()[0].split() == ['#', 'Code']
 
 
 models = {

--- a/eelbrain/_experiment/trf/tests/test_model.py
+++ b/eelbrain/_experiment/trf/tests/test_model.py
@@ -48,6 +48,56 @@ def test_term():
         parse_term('stim~word--b')
 
 
+def test_term_lags():
+    # lag-window overrides
+    term = parse_term('gammatone[0.2:]')
+    assert term.tstart == 0.2
+    assert term.tstop is None
+    assert term.string == 'gammatone[0.2:]'
+    assert term.without_lags() == parse_term('gammatone')
+    assert parse_term(term.string) == term
+
+    term = parse_term('word[-0.1:0.8]')
+    assert term.tstart == -0.1
+    assert term.tstop == 0.8
+    assert parse_term(term.string) == term
+
+    term = parse_term('stim~word-frequency[:0.9]')
+    assert term.stimulus == 'stim'
+    assert term.code == 'word-frequency'
+    assert term.nuts_columns == ('frequency', None)
+    assert term.tstart is None
+    assert term.tstop == 0.9
+    assert term.string == 'stim~word-frequency[:0.9]'
+    assert term.with_stimulus('other').string == 'other~word-frequency[:0.9]'
+
+    # empty slice is a no-op
+    assert parse_term('gammatone[:]') == parse_term('gammatone')
+
+    # tstart must be smaller than tstop
+    with pytest.raises(TRFModelError):
+        parse_term('gammatone[0.5:0.2]')
+
+    # same predictor with different lag windows
+    model = Model.coerce('gammatone[0:0.5] + gammatone[0.5:1]')
+    assert model.name == 'gammatone[0:0.5] + gammatone[0.5:1]'
+    with pytest.raises(TRFModelError):
+        Model.coerce('gammatone[0:0.5] + gammatone[0:0.5]')
+
+    # comparison with lags
+    comparison = Comparison.coerce('x + gammatone[0.2:] > x')
+    assert comparison.x1_only.name == 'gammatone[0.2:]'
+
+
+def test_named_model_lags():
+    # lag overrides distribute to member terms; explicit member lags take precedence
+    named = {'ab': Model.coerce('a + b[0.5:1]')}
+    model = Model.coerce('ab[0.2:0.8]').initialize(named)
+    assert model.name == 'a[0.2:0.8] + b[0.5:1]'
+    model = Model.coerce('ab').initialize(named)
+    assert model.name == 'a + b[0.5:1]'
+
+
 models = {
     'x-abcd': 'x-a + x-b + x-c + x-d',
     'x-ab': 'x-a + x-b',

--- a/eelbrain/_experiment/trf/tests/test_model.py
+++ b/eelbrain/_experiment/trf/tests/test_model.py
@@ -83,6 +83,13 @@ def test_term_lags():
     assert model.name == 'gammatone[0:0.5] + gammatone[0.5:1]'
     with pytest.raises(TRFModelError):
         Model.coerce('gammatone[0:0.5] + gammatone[0:0.5]')
+    # overlapping lag windows for the same predictor
+    with pytest.raises(TRFModelError):
+        Model.coerce('gammatone + gammatone[0.2:]')
+    with pytest.raises(TRFModelError):
+        Model.coerce('gammatone[0:0.6] + gammatone[0.5:1]')
+    with pytest.raises(TRFModelError):
+        Model.coerce('gammatone[:0.5] + gammatone[0.2:]')
 
     # comparison with lags
     comparison = Comparison.coerce('x + gammatone[0.2:] > x')
@@ -96,6 +103,62 @@ def test_named_model_lags():
     assert model.name == 'a[0.2:0.8] + b[0.5:1]'
     model = Model.coerce('ab').initialize(named)
     assert model.name == 'a + b[0.5:1]'
+
+
+def test_comparison_lags():
+    # omitting a lag window keeps the complement in the reduced model
+    comparison = Comparison.coerce('a + b @ b[:1]')
+    assert comparison.x1.name == 'a + b'
+    assert comparison.x0.name == 'a + b[1:]'
+    comparison = Comparison.coerce('a + b @ b[1:]')
+    assert comparison.x0.name == 'a + b[:1]'
+    # interior window: two-piece complement
+    comparison = Comparison.coerce('a + b @ b[0.5:1]')
+    assert comparison.x0.name == 'a + b[:0.5] + b[1:]'
+    # complement within the term's own window; open bounds inherit the term's bound
+    comparison = Comparison.coerce('a + b[0:2] @ b[0:1]')
+    assert comparison.x1.name == 'a + b[0:2]'
+    assert comparison.x0.name == 'a + b[1:2]'
+    comparison = Comparison.coerce('a + b[0:2] @ b[:1]')
+    assert comparison.x1.name == 'a + b[0:2]'
+    assert comparison.x0.name == 'a + b[1:2]'
+    # exact match: full removal
+    comparison = Comparison.coerce('a + b[:1] @ b[:1]')
+    assert comparison.x0.name == 'a'
+    # bare term removes all lag windows of that predictor
+    comparison = Comparison.coerce('a + b[:1] @ b')
+    assert comparison.x0.name == 'a'
+    comparison = Comparison.coerce('a + b[:0.5] + b[0.5:] @ b')
+    assert comparison.x0.name == 'a'
+    # two-sided omit: early vs late window
+    comparison = Comparison.coerce('a + b @ b[:1] > b[1:]')
+    assert comparison.x1.name == 'a + b[:1]'
+    assert comparison.x0.name == 'a + b[1:]'
+    assert comparison.name == 'a + b @ b[:1] > b[1:]'
+    # add with lag windows
+    comparison = Comparison.coerce('a +@ b[:1]')
+    assert comparison.x1.name == 'a + b[:1]'
+    assert comparison.x0.name == 'a'
+    comparison = Comparison.coerce('a +@ b[:1] > b[1:]')
+    assert comparison.x1.name == 'a + b[:1]'
+    assert comparison.x0.name == 'a + b[1:]'
+    # named model: window distributes to member terms, then complements per term
+    named = {'ab': Model.coerce('a + b')}
+    comparison = Comparison.coerce('a + b @ ab[:1]', named)
+    assert comparison.x0.name == 'a[1:] + b[1:]'
+    # model expression subtraction with lag window
+    model = ModelExpression.from_string('ab - b[:1]').initialize(named)
+    assert model.name == 'a + b[1:]'
+
+    # errors
+    with pytest.raises(TRFModelError):  # window not contained in the term's window
+        Comparison.coerce('a + b[:1] @ b[1:2]')
+    with pytest.raises(TRFModelError):  # window straddles a split
+        Comparison.coerce('a + b[:1] + b[1:] @ b[0.5:1.5]')
+    with pytest.raises(TRFModelError):  # predictor not in model
+        Comparison.coerce('a + b @ c[:1]')
+    with pytest.raises(TRFModelError):  # add overlapping window
+        Comparison.coerce('a + b +@ b[:1]')
 
 
 models = {

--- a/eelbrain/_experiment/trf/tests/test_model.py
+++ b/eelbrain/_experiment/trf/tests/test_model.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eelbrain._experiment.trf.model import TRFModelError, Model, ModelExpression, Comparison, parse_term
+from eelbrain._experiment.trf.model import TRFModelError, Model, Comparison, Term, parse_term
 
 
 def test_term():
@@ -79,9 +79,8 @@ def test_term_lags():
         parse_term('gammatone[0.5:0.2]')
 
     # sub-millisecond precision is not supported; bounds snap to the ms grid
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(TRFModelError):
         parse_term('gammatone[0.0005:0.1]')
-    from eelbrain._experiment.trf.model import Term
     assert Term(None, 'gammatone', 0.1 + 0.2, 0.5).tstart == 0.3
 
     # open lag bounds fill in from model-wide defaults
@@ -112,9 +111,9 @@ def test_term_lags():
 def test_named_model_lags():
     # lag overrides distribute to member terms; explicit member lags take precedence
     named = {'ab': Model.coerce('a + b[0.5:1]')}
-    model = Model.coerce('ab[0.2:0.8]').initialize(named)
+    model = Model.coerce('ab[0.2:0.8]', named)
     assert model.name == 'a[0.2:0.8] + b[0.5:1]'
-    model = Model.coerce('ab').initialize(named)
+    model = Model.coerce('ab', named)
     assert model.name == 'a + b[0.5:1]'
 
 
@@ -159,8 +158,8 @@ def test_comparison_lags():
     named = {'ab': Model.coerce('a + b')}
     comparison = Comparison.coerce('a + b @ ab[:1]', named)
     assert comparison.x0.name == 'a[1:] + b[1:]'
-    # model expression subtraction with lag window
-    model = ModelExpression.from_string('ab - b[:1]').initialize(named)
+    # subtracting a lag window from an expanded model keeps the complement
+    model = Model.coerce('ab', named) - Model.coerce('b[:1]')
     assert model.name == 'a + b[1:]'
 
     # difference/intersection decompose lag windows
@@ -182,51 +181,89 @@ def test_comparison_lags():
 
 
 def test_comparison_lags_resolved():
-    "Comparison.resolve_lags resolves open bounds against the model-wide tstart/tstop"
+    "Comparison.resolve_lags re-derives the reduced model with explicit lag windows"
     # omit window beyond the model-wide window: the reduced model would exceed the full model
     with pytest.raises(TRFModelError):
         Comparison.coerce('a + b @ b[0.6:]').resolve_lags(0, 0.5)
     with pytest.raises(TRFModelError):
         Comparison.coerce('a + b @ b[:0.6]').resolve_lags(0, 0.5)
-    # within the model-wide window: resolution is a no-op
+    # within the model-wide window: complements computed from the concrete windows
     comparison = Comparison.coerce('a + b @ b[0.2:]')
-    assert comparison.resolve_lags(0, 0.5) is comparison
     assert comparison.x0.name == 'a + b[:0.2]'
+    resolved = comparison.resolve_lags(0, 0.5)
+    assert resolved.x1.name == 'a[0:0.5] + b[0:0.5]'
+    assert resolved.x0.name == 'a[0:0.5] + b[0:0.2]'
+    assert resolved.name == 'a + b @ b[0.2:]'  # display name preserved
+    assert resolved.resolve_lags(0, 0.5) is resolved  # idempotent
     # two-sided omit: each omitted window is checked against the full model
     Comparison.coerce('a + b @ b[:0.2] > b[0.2:]').resolve_lags(0, 0.5)
     with pytest.raises(TRFModelError):
         Comparison.coerce('a + b @ b[:0.2] > b[0.6:]').resolve_lags(0, 0.5)
-    # direct comparisons carry no omitted windows and only require valid models
+    # direct comparisons re-derive nothing; term windows may exceed the model-wide window
     Comparison.coerce('a + b[:0.6] > a').resolve_lags(0, 0.5)
-    # an omit bound at the model-wide bound: the zero-width complement piece is dropped
+    # an omit bound at the model-wide bound: no empty complement piece is created
     comparison = Comparison.coerce('a + b @ b[0:0.2]')
-    assert comparison.x0.name == 'a + b[:0] + b[0.2:]'
+    assert comparison.x0.name == 'a + b[:0] + b[0.2:]'  # symbolic: piece for lags before 0
     resolved = comparison.resolve_lags(0, 0.5)
-    assert resolved.x0.name == 'a + b[0.2:]'
-    assert resolved.name == 'a + b @ b[0:0.2]'  # display name preserved
+    assert resolved.x0.name == 'a[0:0.5] + b[0.2:0.5]'
+    # the decomposition properties are exact on a resolved comparison
+    assert resolved.x1_only.name == 'b[0:0.2]'
+    assert not resolved.x0_only
+    assert resolved.common_base.name == 'a[0:0.5] + b[0.2:0.5]'
+    # ... including for mixed open/explicit bounds (which compare as unbounded unresolved)
+    resolved = Comparison.coerce('a + b[-0.1:] > a + b').resolve_lags(0, 0.5)
+    assert resolved.x1_only.name == 'b[-0.1:0]'
+    assert not resolved.x0_only
+    assert resolved.common_base.name == 'a[0:0.5] + b[0:0.5]'
 
 
-def test_model_lags_validation():
-    "Model.resolve_lags/validate_lags: complete, non-empty windows given model-wide defaults"
+def test_model_lags_resolution():
+    "Model.resolve_lags: explicit windows from the model-wide defaults"
     model = Model.coerce('a + b[0.1:0.4]')
-    assert model.resolve_lags(0, 0.5) is model
-    model.validate_lags(0, 0.5)
+    resolved = model.resolve_lags(0, 0.5)
+    assert resolved.name == 'a[0:0.5] + b[0.1:0.4]'
+    assert resolved.resolve_lags(0, 0.5) is resolved  # idempotent
     # term windows beyond the model-wide window are allowed
-    Model.coerce('a + b[0.6:0.8]').validate_lags(0, 0.5)
+    assert Model.coerce('a + b[0.6:0.8]').resolve_lags(0, 0.5).name == 'a[0:0.5] + b[0.6:0.8]'
     # if all terms specify complete windows, model-wide defaults are not needed
-    Model.coerce('a[0:0.3] + b[0.1:0.4]').validate_lags(None, None)
+    assert Model.coerce('a[0:0.3] + b[0.1:0.4]').resolve_lags(None, None).name == 'a[0:0.3] + b[0.1:0.4]'
     with pytest.raises(TRFModelError):  # no tstart for a
-        Model.coerce('a + b[0.1:0.4]').validate_lags(None, 0.5)
+        Model.coerce('a + b[0.1:0.4]').resolve_lags(None, 0.5)
     with pytest.raises(TRFModelError):  # no tstop for a
-        Model.coerce('a + b[0.1:0.4]').validate_lags(0, None)
-    with pytest.raises(TRFModelError):  # resolved window of b is negative
+        Model.coerce('a + b[0.1:0.4]').resolve_lags(0, None)
+    with pytest.raises(TRFModelError):  # resolved window of b is empty
         Model.coerce('a + b[0.6:]').resolve_lags(0, 0.5)
-    # a zero-width window covers no lags: dropped by resolve_lags, rejected by validate_lags
-    assert Model.coerce('a + b[0.5:]').resolve_lags(0, 0.5).name == 'a'
-    with pytest.raises(TRFModelError):
-        Model.coerce('a + b[0.5:]').validate_lags(0, 0.5)
-    with pytest.raises(TRFModelError):  # no term covers any lags
-        Model.coerce('b[0.5:]').resolve_lags(0, 0.5)
+    with pytest.raises(TRFModelError):  # resolved window of b is zero-width
+        Model.coerce('a + b[0.5:]').resolve_lags(0, 0.5)
+
+
+def test_model_lags_normalization():
+    "normalize_lags: canonical (x, tstart, tstop) for cache identity"
+    # no overrides: the model-wide bounds are kept
+    model = Model.coerce('a + b')
+    assert model.normalize_lags(0, 0.5) == (model, 0, 0.5)
+    with pytest.raises(TRFModelError):  # bounds required
+        model.normalize_lags(0, None)
+    with pytest.raises(TRFModelError):  # empty model-wide window
+        model.normalize_lags(0.5, 0)
+    # a window shared by all terms moves to the model-wide bounds
+    assert Model.coerce('a[0:0.4] + b[0:0.4]').normalize_lags(0, 0.5) == (Model.coerce('a + b'), 0, 0.4)
+    assert Model.coerce('a[0.1:] + b[0.1:]').normalize_lags(0, 0.5) == (Model.coerce('a + b'), 0.1, 0.5)
+    # distinct windows: every term explicit, model-wide bounds None
+    model, tstart, tstop = Model.coerce('a + b[0.1:0.4]').normalize_lags(0, 0.5)
+    assert model.name == 'a[0:0.5] + b[0.1:0.4]'
+    assert tstart is None and tstop is None
+    assert model.normalize_lags(None, None) == (model, None, None)  # idempotent
+    # comparison: a window shared across both models moves to the model-wide bounds
+    comparison, tstart, tstop = Comparison.coerce('a[0:0.4] + b[0:0.4] > a[0:0.4]').normalize_lags(0, 0.5)
+    assert comparison.x1.name == 'a + b'
+    assert comparison.x0.name == 'a'
+    assert (tstart, tstop) == (0, 0.4)
+    # mixed comparison: explicit windows, model-wide bounds None
+    comparison, tstart, tstop = Comparison.coerce('a + b @ b[0.2:]').normalize_lags(0, 0.5)
+    assert comparison.x1.name == 'a[0:0.5] + b[0:0.5]'
+    assert comparison.x0.name == 'a[0:0.5] + b[0:0.2]'
+    assert tstart is None and tstop is None
 
 
 def test_term_table_lags():
@@ -254,9 +291,6 @@ def test_model():
     assert xy + z == xyz
     assert xyz - z == xy
     assert xy.intersection(yz) == y
-    # subtraction
-    xy2 = ModelExpression.from_string("xyz - z").initialize(named_models)
-    assert xy2 == xy
     # duplicate term
     with pytest.raises(TRFModelError):
         Model.coerce("term-1 + term-2 + term-2")

--- a/eelbrain/_experiment/trf/tests/test_predictor.py
+++ b/eelbrain/_experiment/trf/tests/test_predictor.py
@@ -106,7 +106,7 @@ def test_uts_predictor_generate_continuous_out_of_bounds():
 def test_event_predictor_generate_continuous():
     "EventPredictor._generate_continuous puts a unit impulse at each event's epoch_time"
     uts = UTS(2, 0.1, 10)
-    x = EventPredictor()._generate_continuous(uts, _continuous_events(), parse_term('imp'), 'imp')
+    x = EventPredictor()._generate_continuous(uts, _continuous_events(), parse_term('imp'))
     assert x.time == uts
     expected = np.zeros(10)
     expected[0] = 1.

--- a/eelbrain/_experiment/trf/tests/test_predictor.py
+++ b/eelbrain/_experiment/trf/tests/test_predictor.py
@@ -106,7 +106,7 @@ def test_uts_predictor_generate_continuous_out_of_bounds():
 def test_event_predictor_generate_continuous():
     "EventPredictor._generate_continuous puts a unit impulse at each event's epoch_time"
     uts = UTS(2, 0.1, 10)
-    x = EventPredictor()._generate_continuous(uts, _continuous_events(), parse_term('imp'))
+    x = EventPredictor()._generate_continuous(uts, _continuous_events(), parse_term('imp'), 'imp')
     assert x.time == uts
     expected = np.zeros(10)
     expected[0] = 1.


### PR DESCRIPTION
@nigelflower this should work without invalidating an existing cache

- [x] What happens with `@` comparison syntax?