### PR TITLE
Pipeline GUI Improvements

### DIFF
--- a/doc/pipeline/introduction.rst
+++ b/doc/pipeline/introduction.rst
@@ -163,6 +163,10 @@ Coregistration
     Double-clicking opens the MNE coregistration GUI pre-loaded with the subject's raw file and, if one already exists, the current transformation.
     For subjects without a FreeSurfer reconstruction the GUI opens against the template brain so the user can use MNE's "Scale MRI" feature to create a scaled copy.
 
+When a table takes a long time to fill in, ``--debug`` prints the pipeline's debug log, including the time each individual row of the table took to compute::
+
+    $ eelbrain-gui --debug
+
 
 .. _state-parameters:
 

--- a/doc/pipeline/introduction.rst
+++ b/doc/pipeline/introduction.rst
@@ -163,13 +163,6 @@ Coregistration
     Double-clicking opens the MNE coregistration GUI pre-loaded with the subject's raw file and, if one already exists, the current transformation.
     For subjects without a FreeSurfer reconstruction the GUI opens against the template brain so the user can use MNE's "Scale MRI" feature to create a scaled copy.
 
-A table appears as soon as its rows are known, with each row's status filling in behind it (the status bar counts the rows that are done).
-When that takes a long time, ``--debug`` prints the pipeline's debug log, including the time each individual row took and, for each artifact that was loaded, which pipeline step spent it::
-
-    $ eelbrain-gui --debug
-    DEBUG   :  Load ica-input@ica in 3.139 s: raw-input@raw 3.101 s (1x), ica-input@ica 0.032 s (1x)
-    DEBUG   :  Pipeline GUI ica: row 0 ('01',) in 3.140 s
-
 
 .. _state-parameters:
 

--- a/doc/pipeline/introduction.rst
+++ b/doc/pipeline/introduction.rst
@@ -167,7 +167,7 @@ A table appears as soon as its rows are known, with each row's status filling in
 When that takes a long time, ``--debug`` prints the pipeline's debug log, including the time each individual row took and, for each artifact that was loaded, which pipeline step spent it::
 
     $ eelbrain-gui --debug
-    DEBUG   :  Load ica-input@ica in 3.139 s: raw-input@raw 3.101 s (1x), ica-input@ica 0.032 s (2x)
+    DEBUG   :  Load ica-input@ica in 3.139 s: raw-input@raw 3.101 s (1x), ica-input@ica 0.032 s (1x)
     DEBUG   :  Pipeline GUI ica: row 0 ('01',) in 3.140 s
 
 

--- a/doc/pipeline/introduction.rst
+++ b/doc/pipeline/introduction.rst
@@ -164,9 +164,11 @@ Coregistration
     For subjects without a FreeSurfer reconstruction the GUI opens against the template brain so the user can use MNE's "Scale MRI" feature to create a scaled copy.
 
 A table appears as soon as its rows are known, with each row's status filling in behind it (the status bar counts the rows that are done).
-When that takes a long time, ``--debug`` prints the pipeline's debug log, including the time each individual row took to compute::
+When that takes a long time, ``--debug`` prints the pipeline's debug log, including the time each individual row took and, for each artifact that was loaded, which pipeline step spent it::
 
     $ eelbrain-gui --debug
+    DEBUG   :  Load ica-input@ica in 3.139 s: raw-input@raw 3.101 s (1x), ica-input@ica 0.032 s (2x)
+    DEBUG   :  Pipeline GUI ica: row 0 ('01',) in 3.140 s
 
 
 .. _state-parameters:

--- a/doc/pipeline/introduction.rst
+++ b/doc/pipeline/introduction.rst
@@ -163,7 +163,8 @@ Coregistration
     Double-clicking opens the MNE coregistration GUI pre-loaded with the subject's raw file and, if one already exists, the current transformation.
     For subjects without a FreeSurfer reconstruction the GUI opens against the template brain so the user can use MNE's "Scale MRI" feature to create a scaled copy.
 
-When a table takes a long time to fill in, ``--debug`` prints the pipeline's debug log, including the time each individual row of the table took to compute::
+A table appears as soon as its rows are known, with each row's status filling in behind it (the status bar counts the rows that are done).
+When that takes a long time, ``--debug`` prints the pipeline's debug log, including the time each individual row took to compute::
 
     $ eelbrain-gui --debug
 

--- a/eelbrain/_experiment/derivative_cache/__init__.py
+++ b/eelbrain/_experiment/derivative_cache/__init__.py
@@ -19,6 +19,7 @@ from .base import (
     ExternalArtifactDerivative,
     Input,
     JobInputsChangedError,
+    LoadProfile,
     OptionSpec,
     ProtectedArtifactError,
     Request,

--- a/eelbrain/_experiment/derivative_cache/base.py
+++ b/eelbrain/_experiment/derivative_cache/base.py
@@ -55,7 +55,7 @@ and removed by :mod:`.garbage_collection`; the entry points are
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
@@ -1890,7 +1890,9 @@ class Request(Generic[T]):
         ``view`` is accepted; passing ``state``, ``options``, or ``controls``
         raises :class:`TypeError`.
         """
-        with self.registry._load_context(), self.registry._profile_load(self):
+        # A dependency load is profiled by the dependency's own load()
+        profile = self.registry._profile_load(self) if name is None else nullcontext()
+        with self.registry._load_context(), profile:
             return self._load(name, state, options, view=view, controls=controls)
 
     def _resolve_target(

--- a/eelbrain/_experiment/derivative_cache/base.py
+++ b/eelbrain/_experiment/derivative_cache/base.py
@@ -54,7 +54,7 @@ and removed by :mod:`.garbage_collection`; the entry points are
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager, nullcontext
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, field, fields
@@ -1328,7 +1328,7 @@ class LoadProfile:
         self._nested = 0.  # seconds the current load has spent in nested loads
 
     @contextmanager
-    def measure(self, name: str):
+    def measure(self, name: str) -> Iterator[None]:
         """Time one load of node ``name``, excluding the loads nested inside it."""
         outer_nested = self._nested
         self._nested = 0.
@@ -2058,7 +2058,7 @@ class DerivativeRegistry:
             self._validation_cache.reset(token)
 
     @contextmanager
-    def _profile_load(self, ctx: Request):
+    def _profile_load(self, ctx: Request) -> Iterator[None]:
         """Time one load of ``ctx``, and log where the outermost one spent its time.
 
         A no-op unless :attr:`profile_loads` is set; see :class:`LoadProfile`.

--- a/eelbrain/_experiment/derivative_cache/base.py
+++ b/eelbrain/_experiment/derivative_cache/base.py
@@ -66,6 +66,7 @@ from pathlib import Path
 import pickle
 import re
 import shutil
+import time
 import tomllib
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
 from uuid import uuid4
@@ -1308,6 +1309,45 @@ def compare_manifests(stored: ArtifactManifest | None, current: ArtifactManifest
     return None
 
 
+class LoadProfile:
+    """Time spent per node during one top-level :meth:`Request.load`.
+
+    A load walks the dependency graph, so its total says nothing about where the
+    time went: a slow raw file, a slow rebuild and a slow cache walk all look the
+    same. This attributes the time to the node that spent it, by subtracting each
+    nested load from the load that made it, so the times sum to the total.
+
+    Switched on per experiment with :attr:`DerivativeRegistry.profile_loads`
+    (``eelbrain-gui --debug``); off, no measurement is taken at all.
+    """
+
+    def __init__(self):
+        self.self_time: dict[str, float] = {}  # node name -> seconds spent in it
+        self.calls: dict[str, int] = {}  # node name -> number of loads
+        self.total = 0.  # seconds of the load that finished last, i.e. the outermost one
+        self._nested = 0.  # seconds the current load has spent in nested loads
+
+    @contextmanager
+    def measure(self, name: str):
+        """Time one load of node ``name``, excluding the loads nested inside it."""
+        outer_nested = self._nested
+        self._nested = 0.
+        t_start = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed = time.perf_counter() - t_start
+            self.self_time[name] = self.self_time.get(name, 0.) + elapsed - self._nested
+            self.calls[name] = self.calls.get(name, 0) + 1
+            self._nested = outer_nested + elapsed
+            self.total = elapsed
+
+    def summary(self, limit: int = 4) -> str:
+        """The nodes that took the longest, most expensive first."""
+        ranked = sorted(self.self_time, key=self.self_time.get, reverse=True)
+        return ', '.join(f"{name} {self.self_time[name]:.3f} s ({self.calls[name]}x)" for name in ranked[:limit])
+
+
 class Request(Generic[T]):
     """One bound request for data from the dependency graph.
 
@@ -1844,7 +1884,7 @@ class Request(Generic[T]):
         ``view`` is accepted; passing ``state``, ``options``, or ``controls``
         raises :class:`TypeError`.
         """
-        with self.registry._load_context():
+        with self.registry._load_context(), self.registry._profile_load(self):
             return self._load(name, state, options, view=view, controls=controls)
 
     def _resolve_target(
@@ -1992,6 +2032,10 @@ class DerivativeRegistry:
         # Reuse cache-validity results within one top-level Request.load().
         # Artifacts themselves are not shared because callers can mutate them.
         self._validation_cache: ContextVar[dict[tuple[str, str], CacheInvalidation | None] | None] = ContextVar(f'{type(self).__name__}-{id(self)}-validation-cache', default=None)
+        # Log where each top-level load spends its time (see LoadProfile); off by
+        # default, because the measurement is only worth taking when it is read.
+        self.profile_loads = False
+        self._load_profile: ContextVar[LoadProfile | None] = ContextVar(f'{type(self).__name__}-{id(self)}-load-profile', default=None)
 
     @contextmanager
     def _load_context(self):
@@ -2004,6 +2048,28 @@ class DerivativeRegistry:
             yield
         finally:
             self._validation_cache.reset(token)
+
+    @contextmanager
+    def _profile_load(self, ctx: Request):
+        """Time one load of ``ctx``, and log where the outermost one spent its time.
+
+        A no-op unless :attr:`profile_loads` is set; see :class:`LoadProfile`.
+        """
+        if not self.profile_loads:
+            yield
+            return
+        profile = self._load_profile.get()
+        outermost = profile is None
+        if outermost:
+            profile = LoadProfile()
+            token = self._load_profile.set(profile)
+        try:
+            with profile.measure(ctx.node.name):
+                yield
+        finally:
+            if outermost:
+                self._load_profile.reset(token)
+                self.log.debug(f"Load {ctx.node.name} in {profile.total:.3f} s: {profile.summary()}")
 
     @staticmethod
     def _validation_key(ctx: Request) -> tuple[str, str]:

--- a/eelbrain/_experiment/derivative_cache/base.py
+++ b/eelbrain/_experiment/derivative_cache/base.py
@@ -1343,7 +1343,13 @@ class LoadProfile:
             self.total = elapsed
 
     def summary(self, limit: int = 4) -> str:
-        """The nodes that took the longest, most expensive first."""
+        """The nodes that took the longest, most expensive first.
+
+        Parameters
+        ----------
+        limit
+            Number of nodes to list.
+        """
         ranked = sorted(self.self_time, key=self.self_time.get, reverse=True)
         return ', '.join(f"{name} {self.self_time[name]:.3f} s ({self.calls[name]}x)" for name in ranked[:limit])
 

--- a/eelbrain/_experiment/derivative_cache/job.py
+++ b/eelbrain/_experiment/derivative_cache/job.py
@@ -173,37 +173,25 @@ class JobSpec:
         # protection check runs at the start of its make_job, and a file another
         # session writes during the (potentially long) load was never covered by that
         # check, so it must not become the baseline that save_result may overwrite.
-        artifact = None
         if ctx.node.cache_policy is CachePolicy.EXTERNAL and self.path.exists():
             artifact = file_fingerprint(ctx.root, self.path)
-        # Fingerprint the inputs before they are read, and check afterward that they
-        # held still: the job carries data read during the load, so fingerprints taken
-        # after it would describe data the job does not hold -- and being equal to the
-        # current state, they would mark that artifact valid rather than stale.
-        provenance = JobProvenance(ctx.dependency_fingerprints(), ctx.current_fingerprint(), artifact)
-        # For a derivative, the same contexts load_artifact wraps build() in, so its
-        # loads are restricted to declared dependencies and key fields, and its
-        # warnings are recorded, whether the artifact is computed in place or through
-        # a job. An input has no in-place build to mirror, and may load beyond its
-        # declared dependency edges (ICA loads bad channels and per-run source raws).
+        else:
+            artifact = None
+        # Fingerprint the inputs before they are read to check afterward that they held still
+        dependencies, fingerprint = ctx.dependency_fingerprints(), ctx.current_fingerprint()
+        # For a derivative, the same contexts load_artifact wraps build() in
         if isinstance(ctx.node, Derivative):
             with ctx._build_deps_context(), ctx.registry._node_warning_context(ctx), ctx._state_check_context():
                 job = ctx.node.make_job(ctx)
         else:
             job = ctx.node.make_job(ctx)
-        # Check that the inputs are unchanged. Quick fingerprints are excluded: they
-        # may change spuriously (see DependencyNode.dependency_fingerprint_quick), and
-        # loading itself can move one (a load may refresh the file behind it, as a TRF
-        # predictor's reference file is). The manifest is then filed with the quick
-        # fingerprints as they are after the load, so that validating the artifact can
-        # take the quick path.
-        dependencies, fingerprint = ctx.dependency_fingerprints(), ctx.current_fingerprint()
-        for before, after in ((provenance.dependencies, dependencies), (provenance.fingerprint, fingerprint)):
-            difference = find_difference(before, after, strip_quick=True)
+        # Check that the inputs are unchanged and record most recent quick fingerprints
+        provenance = JobProvenance(ctx.dependency_fingerprints(), ctx.current_fingerprint(), artifact)
+        for before, after in ((dependencies, provenance.dependencies), (fingerprint, provenance.fingerprint)):
+            difference = find_difference(before, after, strip_quick=True)  # Quick fingerprints are excluded as they may change spuriously
             if difference is not None:
                 path, old, new = difference
                 raise JobInputsChangedError(ctx.node.name, format_difference_path(path), old, new)
-        provenance = replace(provenance, dependencies=dependencies, fingerprint=fingerprint)
 
         ctx.node.log_job(ctx, self.path)
         return replace(job, key=self.key, node=ctx.node.name, provenance=provenance)

--- a/eelbrain/_experiment/derivative_cache/job.py
+++ b/eelbrain/_experiment/derivative_cache/job.py
@@ -67,9 +67,9 @@ class JobProvenance:
     Attributes
     ----------
     dependencies
-        Dependency fingerprints as of before the load, verified unchanged after
-        it. Everything a job is computed from is loaded through
-        ``ctx.load(...)``, so this covers all of it.
+        Dependency fingerprints as of the load, verified to be the same before
+        and after it (quick fingerprints aside). Everything a job is computed
+        from is loaded through ``ctx.load(...)``, so this covers all of it.
     fingerprint
         The node's own fingerprint, taken and verified the same way. Mostly
         definitions and state, which the request holds fixed -- but a node may
@@ -193,13 +193,17 @@ class JobSpec:
             job = ctx.node.make_job(ctx)
         # Check that the inputs are unchanged. Quick fingerprints are excluded: they
         # may change spuriously (see DependencyNode.dependency_fingerprint_quick), and
-        # loading itself can move one (e.g. loading bad channels builds a missing
-        # channels.tsv file, relocating the quick fingerprint to the new file).
-        for before, after in ((provenance.dependencies, ctx.dependency_fingerprints()), (provenance.fingerprint, ctx.current_fingerprint())):
+        # loading itself can move one (a load may refresh the file behind it, as a TRF
+        # predictor's reference file is). The manifest is then filed with the quick
+        # fingerprints as they are after the load, so that validating the artifact can
+        # take the quick path.
+        dependencies, fingerprint = ctx.dependency_fingerprints(), ctx.current_fingerprint()
+        for before, after in ((provenance.dependencies, dependencies), (provenance.fingerprint, fingerprint)):
             difference = find_difference(before, after, strip_quick=True)
             if difference is not None:
                 path, old, new = difference
                 raise JobInputsChangedError(ctx.node.name, format_difference_path(path), old, new)
+        provenance = replace(provenance, dependencies=dependencies, fingerprint=fingerprint)
 
         ctx.node.log_job(ctx, self.path)
         return replace(job, key=self.key, node=ctx.node.name, provenance=provenance)

--- a/eelbrain/_experiment/derivative_cache/job.py
+++ b/eelbrain/_experiment/derivative_cache/job.py
@@ -191,9 +191,12 @@ class JobSpec:
                 job = ctx.node.make_job(ctx)
         else:
             job = ctx.node.make_job(ctx)
-        # Check that the inputs are unchanged
+        # Check that the inputs are unchanged. Quick fingerprints are excluded: they
+        # may change spuriously (see DependencyNode.dependency_fingerprint_quick), and
+        # loading itself can move one (e.g. loading bad channels builds a missing
+        # channels.tsv file, relocating the quick fingerprint to the new file).
         for before, after in ((provenance.dependencies, ctx.dependency_fingerprints()), (provenance.fingerprint, ctx.current_fingerprint())):
-            difference = find_difference(before, after)
+            difference = find_difference(before, after, strip_quick=True)
             if difference is not None:
                 path, old, new = difference
                 raise JobInputsChangedError(ctx.node.name, format_difference_path(path), old, new)

--- a/eelbrain/_experiment/derivative_cache/tests/test_derivative_cache.py
+++ b/eelbrain/_experiment/derivative_cache/tests/test_derivative_cache.py
@@ -2244,3 +2244,4 @@ def test_profile_loads_logs_where_a_load_spent_its_time(caplog):
     assert len(lines) == 1
     assert lines[0].startswith('Load summary in ')
     assert 'summary ' in lines[0] and 'value ' in lines[0]
+    assert lines[0].count('(1x)') == 2  # loading the dependency does not count as a load of the node that asked for it

--- a/eelbrain/_experiment/derivative_cache/tests/test_derivative_cache.py
+++ b/eelbrain/_experiment/derivative_cache/tests/test_derivative_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+import time
 
 import pytest
 
@@ -18,6 +19,7 @@ from eelbrain._experiment.derivative_cache import (
     Request,
     DerivativeRegistry,
     Input,
+    LoadProfile,
     ProtectedArtifactError,
     UncachedDerivative,
     VersionedInput,
@@ -2196,3 +2198,47 @@ def test_external_input_has_artifact_members():
     with pytest.raises(TypeError, match="uncached derivative 'ephemeral'"):
         handle.key()
     assert handle.is_valid() is False
+
+
+def test_load_profile_attributes_time_to_the_node_that_spent_it():
+    "A nested load counts towards its own node, not the load that made it"
+    profile = LoadProfile()
+    with profile.measure('outer'):
+        with profile.measure('inner'):
+            time.sleep(0.02)
+        with profile.measure('inner'):
+            time.sleep(0.02)
+        time.sleep(0.01)
+
+    assert profile.calls == {'outer': 1, 'inner': 2}
+    # the two nested loads are subtracted from the outer one, so the times sum to the total
+    assert profile.self_time['inner'] == pytest.approx(0.04, abs=0.02)
+    assert profile.self_time['outer'] == pytest.approx(0.01, abs=0.02)
+    assert sum(profile.self_time.values()) == pytest.approx(profile.total, abs=0.001)
+    # the summary ranks the nodes by the time they spent, most expensive first
+    assert profile.summary().startswith('inner ')
+    assert profile.summary(limit=1).count(',') == 0
+
+
+def _profile_lines(caplog) -> list[str]:
+    "The per-node breakdowns LoadProfile logged, apart from the cache's own Load lines"
+    return [r.message for r in caplog.records if r.message.startswith('Load ') and ' s: ' in r.message]
+
+
+def test_profile_loads_logs_where_a_load_spent_its_time(caplog):
+    "With profiling on, every top-level load reports its per-node breakdown"
+    pipeline, registry, source, value, *_ = make_registry()
+
+    with caplog.at_level(logging.DEBUG, logger=LOG.name):
+        registry.resolve('value', state=DEFAULT_STATE).load()
+    assert _profile_lines(caplog) == []  # off by default
+
+    registry.profile_loads = True
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=LOG.name):
+        registry.resolve('summary', state=DEFAULT_STATE).load()
+    # one line for the top-level load, naming the dependency it loaded on the way
+    lines = _profile_lines(caplog)
+    assert len(lines) == 1
+    assert lines[0].startswith('Load summary in ')
+    assert 'summary ' in lines[0] and 'value ' in lines[0]

--- a/eelbrain/_experiment/derivative_cache/tests/test_derivative_cache.py
+++ b/eelbrain/_experiment/derivative_cache/tests/test_derivative_cache.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -2200,21 +2200,23 @@ def test_external_input_has_artifact_members():
     assert handle.is_valid() is False
 
 
-def test_load_profile_attributes_time_to_the_node_that_spent_it():
+def test_load_profile_attributes_time_to_the_node_that_spent_it(monkeypatch):
     "A nested load counts towards its own node, not the load that made it"
+    now = [0.]
+    monkeypatch.setattr('eelbrain._experiment.derivative_cache.base.time', SimpleNamespace(perf_counter=lambda: now[0]))
     profile = LoadProfile()
     with profile.measure('outer'):
         with profile.measure('inner'):
-            time.sleep(0.02)
+            now[0] += 0.02
         with profile.measure('inner'):
-            time.sleep(0.02)
-        time.sleep(0.01)
+            now[0] += 0.02
+        now[0] += 0.01
 
     assert profile.calls == {'outer': 1, 'inner': 2}
     # the two nested loads are subtracted from the outer one, so the times sum to the total
-    assert profile.self_time['inner'] == pytest.approx(0.04, abs=0.02)
-    assert profile.self_time['outer'] == pytest.approx(0.01, abs=0.02)
-    assert sum(profile.self_time.values()) == pytest.approx(profile.total, abs=0.001)
+    assert profile.self_time['inner'] == pytest.approx(0.04)
+    assert profile.self_time['outer'] == pytest.approx(0.01)
+    assert sum(profile.self_time.values()) == pytest.approx(profile.total)
     # the summary ranks the nodes by the time they spent, most expensive first
     assert profile.summary().startswith('inner ')
     assert profile.summary(limit=1).count(',') == 0

--- a/eelbrain/_experiment/derivative_cache/tests/test_jobs.py
+++ b/eelbrain/_experiment/derivative_cache/tests/test_jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import pickle
 import warnings
 from dataclasses import dataclass
@@ -22,6 +23,7 @@ from eelbrain._experiment.derivative_cache import (
 )
 from eelbrain._experiment.derivative_cache.tests.test_derivative_cache import (
     DEFAULT_STATE,
+    CountingQuickInput,
     NarrowingDerivative,
     SourceInput,
     make_empty_registry,
@@ -91,6 +93,25 @@ class RacyJobDerivative(JobDerivative):
             job = _EchoJob(ctx.load('source'))
         if self.interrupt is not None:
             self._source.source_path(ctx.state['subject']).write_text(self.interrupt)
+        return job
+
+
+class TouchingJobDerivative(JobDerivative):
+    "Job derivative whose load refreshes its input file, moving the input's quick fingerprint"
+    name = 'touching-job'
+
+    def __init__(self, source: CountingQuickInput):
+        self._source = source
+
+    def dependencies(self, ctx: Request) -> tuple[Dependency, ...]:
+        return (Dependency('counting'),)
+
+    def make_job(self, ctx: Request) -> _EchoJob:
+        with ctx._build_deps_context():
+            job = _EchoJob(ctx.load('counting'))
+        path = self._source.path(ctx)
+        mtime_ns = path.stat().st_mtime_ns + 10**9
+        os.utime(path, ns=(mtime_ns, mtime_ns))
         return job
 
 
@@ -280,6 +301,23 @@ def test_job_refuses_inputs_that_change_during_the_load():
     job = spec.make_job()
     assert spec.save_result(job, job()) == 'CHANGED'
     assert JobSpec(registry.resolve('racy-job', state=DEFAULT_STATE)).is_done
+
+
+def test_job_files_the_quick_fingerprints_as_they_are_after_the_load():
+    "A quick fingerprint that moves during the load is not a changed input, and the manifest records where it moved to"
+    root, registry = make_empty_registry()
+    source = CountingQuickInput(root)
+    registry.register(source)
+    registry.register(TouchingJobDerivative(source))
+    source.path(registry.resolve('counting', state=DEFAULT_STATE)).write_text('hello')
+
+    spec = JobSpec(registry.resolve('touching-job', state=DEFAULT_STATE))
+    job = spec.make_job()
+    assert spec.save_result(job, job()) == 'HELLO'
+    # validating the result takes the quick path, rather than recomputing the full fingerprint
+    source.full_calls = 0
+    assert registry.resolve('touching-job', state=DEFAULT_STATE).is_valid()
+    assert source.full_calls == 0
 
 
 def test_job_save_result_requires_a_matching_job():

--- a/eelbrain/_experiment/exceptions.py
+++ b/eelbrain/_experiment/exceptions.py
@@ -1,4 +1,5 @@
 """Exceptions for Pipeline"""
+from collections.abc import Sequence
 
 
 class FileMissingError(Exception):
@@ -18,8 +19,25 @@ class ICAChannelsChangedError(Exception):
 
     Raised when launching the ICA component-selection GUI but the sensors in
     the current data no longer match those the ICA was estimated on.
+
+    Parameters
+    ----------
+    path
+        Path to the ICA file.
+    bads_before
+        Bad channels when the ICA was estimated (data channels that are absent
+        from the ICA, since they were excluded from the decomposition).
+    bads_after
+        Bad channels in the current data.
     """
 
-    def __init__(self, path: str):
+    def __init__(
+            self,
+            path: str,
+            bads_before: Sequence[str],
+            bads_after: Sequence[str],
+    ):
         self.path = path
-        super().__init__("Bad channels have changed since creating the ICA")
+        self.bads_before = tuple(bads_before)
+        self.bads_after = tuple(bads_after)
+        super().__init__(f"Bad channels have changed since creating the ICA (before: {', '.join(self.bads_before) or 'none'}; now: {', '.join(self.bads_after) or 'none'})")

--- a/eelbrain/_experiment/gui.py
+++ b/eelbrain/_experiment/gui.py
@@ -29,7 +29,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument(
         '--debug',
         action='store_true',
-        help='Print debug output, including how long each step of a table refresh takes; shorthand for --log-level debug',
+        help='Print debug output at --log-level debug, and log how long each step of a table refresh takes and which node each artifact load spends its time in',
     )
     parser.add_argument(
         '--migrate',
@@ -48,6 +48,9 @@ def main(argv: Sequence[str] | None = None) -> None:
     from .load_pipeline import load_pipeline
 
     pipeline = load_pipeline(args.path, log_level=args.log_level or ('debug' if args.debug else None))
+    if args.debug:
+        # attribute a slow table row to the node whose load took the time
+        pipeline._derivatives.profile_loads = True
 
     if args.migrate:
         from .migration import migrate_derivatives

--- a/eelbrain/_experiment/gui.py
+++ b/eelbrain/_experiment/gui.py
@@ -27,6 +27,11 @@ def main(argv: Sequence[str] | None = None) -> None:
         help='Determine log level for log messages printed to the terminal; overrides Pipeline.screen_log_level for the loaded pipeline',
     )
     parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Print debug output, including how long each step of a table refresh takes; shorthand for --log-level debug',
+    )
+    parser.add_argument(
         '--migrate',
         action='store_true',
         help='Migrate legacy derivative files (ICA, trans, bad channels, epoch rejection) to the current BIDS-style layout and exit without opening the GUI',
@@ -42,7 +47,7 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     from .load_pipeline import load_pipeline
 
-    pipeline = load_pipeline(args.path, log_level=args.log_level)
+    pipeline = load_pipeline(args.path, log_level=args.log_level or ('debug' if args.debug else None))
 
     if args.migrate:
         from .migration import migrate_derivatives

--- a/eelbrain/_experiment/pipeline.py
+++ b/eelbrain/_experiment/pipeline.py
@@ -2452,9 +2452,11 @@ class Pipeline(StateModel):
         try:
             frame = gui.select_components(path, display_data, sysname, adjacency, decim, debug, events=labeled_events)
         except DimensionMismatchError as error:
-            # The sensors no longer match those the ICA was estimated on, which
-            # in this context means the bad channels have changed.
-            raise ICAChannelsChangedError(path) from error
+            # The sensors no longer match those the ICA was estimated on
+            ica_ch_names = mne.preprocessing.read_ica(path).ch_names
+            picks = mne.pick_types(info, meg=True, eeg=True, ref_meg=False, exclude=[])
+            bads_before = [info.ch_names[i] for i in picks if info.ch_names[i] not in ica_ch_names]
+            raise ICAChannelsChangedError(path, bads_before, bads) from error
         return frame
 
     def make_bad_channels_selection(

--- a/eelbrain/_experiment/pipeline.py
+++ b/eelbrain/_experiment/pipeline.py
@@ -2453,10 +2453,8 @@ class Pipeline(StateModel):
             frame = gui.select_components(path, display_data, sysname, adjacency, decim, debug, events=labeled_events)
         except DimensionMismatchError as error:
             # The sensors no longer match those the ICA was estimated on
-            ica_ch_names = mne.preprocessing.read_ica(path).ch_names
-            picks = mne.pick_types(info, meg=True, eeg=True, ref_meg=False, exclude=[])
-            bads_before = [info.ch_names[i] for i in picks if info.ch_names[i] not in ica_ch_names]
-            raise ICAChannelsChangedError(path, bads_before, bads) from error
+            bads_before = pipe._check_ica_channels(mne.preprocessing.read_ica(path), info, return_missing=True)
+            raise ICAChannelsChangedError(path, sorted(bads_before), info['bads']) from error
         return frame
 
     def make_bad_channels_selection(

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -72,10 +72,10 @@ def _format_user_error(error: Exception) -> tuple[str, str] | None:
 def _error_dialog_args(error: Exception) -> tuple[str, str, str | None]:
     """Return ``(tb, title, message)`` for :meth:`PipelineFrame._show_error`.
 
-    Must be called from the ``except`` block handling ``error``; ``message``
-    is ``None`` for unexpected errors, selecting the bug-report presentation.
+    ``message`` is ``None`` for unexpected errors, selecting the bug-report
+    presentation.
     """
-    tb = traceback.format_exc()
+    tb = ''.join(traceback.format_exception(error))
     dialog = _format_user_error(error)
     if dialog is None:
         return tb, "Error", None
@@ -166,6 +166,8 @@ TRANSIENT_STATUS = ('queued', '⟳')
 # Status of a row whose artifact has not been looked at yet: the first pass of a
 # refresh lays out the table, the second fills these in (see PipelineFrame._refresh_thread)
 LOADING = '…'
+# Status of a row whose artifact could not be inspected or computed; always shown red
+ERROR = 'error'
 # Stands in for a detail column that has no value because the artifact is missing
 PLACEHOLDER = '—'
 GREY = wx.Colour(150, 150, 150)
@@ -359,7 +361,7 @@ class BadChannelsTask(Task):
     name = 'bad_chs'
     label = "Bad channels"
     detail_columns = (('N bad', 90),)
-    missing_status = 'error'  # loading seeds a missing channels.tsv, so the only failure is bad data
+    missing_status = ERROR  # loading seeds a missing channels.tsv, so the only failure is bad data
     done_status = 'done'
     summary = "bad channels defined"
     recording_unit = 'recordings'
@@ -1059,7 +1061,7 @@ class PipelineFrame(EelbrainFrame):
         painted the default one, so that the list can still invert them when they
         are selected.
         """
-        colour = self._current_task().row_colour(row, self._layout)
+        colour = wx.RED if row[self._layout.status_col] == ERROR else self._current_task().row_colour(row, self._layout)
         self._list.SetItemTextColour(idx, wx.NullColour if colour is None else colour)
 
     def _set_row_result(self, idx: int, status: str, values: tuple[str, ...]) -> None:
@@ -1174,6 +1176,7 @@ class PipelineFrame(EelbrainFrame):
         task, _, _, _, layout = scope
         log = self._pipeline._log
         n_filled = 0
+        first_error = None  # shown once the pass is over, so that it does not stall the rest
         t_start = time.time()
         try:
             with self._pipeline_lock:
@@ -1189,15 +1192,19 @@ class PipelineFrame(EelbrainFrame):
             t_start = time.time()
             with self._pipeline_lock:
                 t_locked = time.time()
-                for index, (combo, row, spec) in enumerate(self._iter_rows(token, scope, combos)):
+                for index, (combo, row, spec, error) in enumerate(self._iter_rows(token, scope, combos)):
                     wx.CallAfter(self._fill_row, token, scope, index, combo, row, spec)
                     n_filled += 1
+                    if error is not None and first_error is None:
+                        first_error = error
         except _AbortRequested:
             return  # app exit already scheduled
         except Exception as error:
             wx.CallAfter(self._show_error, *_error_dialog_args(error))
             return
         log.debug(f"Pipeline GUI {task.name}: {n_filled} row details in {time.time() - t_locked:.3f} s, after waiting {t_locked - t_start:.3f} s for the pipeline")
+        if first_error is not None:
+            wx.CallAfter(self._show_error, *_error_dialog_args(first_error))
 
     def _show_error(self, tb: str, title: str = "Error", message: str | None = None):
         self.SetStatusText("Error")
@@ -1486,7 +1493,7 @@ class PipelineFrame(EelbrainFrame):
             return
         i = self._displayed_row(scope, combo)
         if i != -1:
-            self._list.SetItem(i, self._layout.status_col, 'error')
+            self._list.SetItem(i, self._layout.status_col, ERROR)
         self._update_progress()
         self._show_error(tb, f"{title}: {' '.join(combo)}", message)
 
@@ -1672,15 +1679,17 @@ class PipelineFrame(EelbrainFrame):
             token: object,
             scope: tuple,  # see :meth:`_table_scope`
             combos: Sequence[tuple[str, ...]],
-    ) -> Iterator[tuple[tuple[str, ...], tuple[str, ...], JobSpec | None]]:
-        """Yield ``(combo, row, job spec)`` for every row of the table.
+    ) -> Iterator[tuple[tuple[str, ...], tuple[str, ...], JobSpec | None, Exception | None]]:
+        """Yield ``(combo, row, job spec, error)`` for every row of the table.
 
         Second pass of a refresh, over the rows the first pass found: this is where a
         row's artifact is inspected, which for the ICA task means validating it against
         the raw data it was estimated from -- one raw file per recording. Rows are
         therefore yielded one at a time, so that the caller can show each as soon as it
         resolves. ``spec`` is ``None`` for a row whose artifact the compute queue cannot
-        make.
+        make. A row whose inspection raises is yielded with status :data:`ERROR` and the
+        exception as ``error``, so that one broken artifact does not hide the rest of
+        the table; ``error`` is ``None`` otherwise.
 
         Parameters
         ----------
@@ -1701,75 +1710,79 @@ class PipelineFrame(EelbrainFrame):
                     return
                 if combo != (COMMON_BRAIN_ROW,):
                     pipeline.set(**constants, **dict(zip(layout.key_fields, combo)))
-                spec = None
-
-                if task.name == 'bad_chs':
-                    source_name = pipeline._raw.root_source_name(raw_name)
-                    bads_ctx = pipeline._resolve_derivative(raw_bad_channels_input_name(source_name))
-                    try:
-                        bads = bads_ctx.load()  # seeds a missing derivatives channels.tsv
-                    except DataError:  # EEG channels without positions
-                        row = task.missing_row(combo, layout)
-                    else:
-                        row = (*combo, task.done_status, str(len(bads)))
-
-                elif task.name == 'ica':
-                    ctx = pipeline._resolve_derivative(ica_input_name(raw_name))
-                    spec = JobSpec(ctx)
-                    status = ctx.load(view='status')
-                    if status == 'ok':
+                spec = error = None
+                try:
+                    if task.name == 'bad_chs':
+                        source_name = pipeline._raw.root_source_name(raw_name)
+                        bads_ctx = pipeline._resolve_derivative(raw_bad_channels_input_name(source_name))
                         try:
-                            ica = ctx.load()
-                            row = (*combo, task.done_status, *task.result_columns(ica))
-                        except ProtectedArtifactError as error:
-                            if bulk_choice is None:
-                                choice, apply_to_all = self._ask_stale_ica(combo[0], error, allow_apply_to_all=True)
-                                if apply_to_all:
-                                    bulk_choice = choice
-                            else:
-                                choice = bulk_choice
-                            row = self._handle_stale_ica(combo, scope, error, choice)
-                    elif status == 'missing-ica':
-                        row = task.missing_row(combo, layout)
-                    else:
-                        row = task.missing_row(combo, layout, 'no data')
-
-                elif task.name == 'epoch_rej':
-                    rej = pipeline._epoch_rejection[epoch_rejection]
-                    node_name = 'epoch-rejection-input' if isinstance(rej, ManualRejection) else 'epoch-rejection-channel-model'
-                    rej_ctx = pipeline._resolve_derivative(node_name)
-                    if isinstance(rej, ManualRejection):
-                        path = rej_ctx.node.path(rej_ctx)  # an input, with no resolved artifact path
-                    else:
-                        spec = JobSpec(rej_ctx)
-                        # Existence, not spec.is_done: validating (or rebuilding) every
-                        # subject's rejection file on each refresh would be far too expensive.
-                        path = spec.path
-                    if path.exists():
-                        ds = load.unpickle(path)
-                        row = (*combo, task.done_status, *task.result_columns(ds))
-                    else:
-                        row = task.missing_row(combo, layout)
-
-                elif task.name == 'mri':
-                    subjects_dir = pipeline.root / MRI_SDIR
-                    if combo == (COMMON_BRAIN_ROW,):
-                        mrisubject = pipeline.get('common_brain')
-                        has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
-                        status = task.done_status if has_recon else COMMON_BRAIN_MISSING
-                    else:
-                        mrisubject = pipeline.get('mrisubject')
-                        has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
-                        if has_recon:
-                            status = 'template' if is_fake_mri(subjects_dir / mrisubject) else task.done_status
+                            bads = bads_ctx.load()  # seeds a missing derivatives channels.tsv
+                        except DataError:  # EEG channels without positions
+                            row = task.missing_row(combo, layout)
                         else:
-                            status = task.missing_status
-                    row = (*combo, mrisubject, status)
+                            row = (*combo, task.done_status, str(len(bads)))
 
-                elif task.name == 'coreg':
-                    mrisubject = pipeline.get('mrisubject')
-                    trans_ctx = pipeline._resolve_derivative('trans-input')
-                    has_trans = trans_ctx.node.exists(trans_ctx)
-                    row = (*combo, mrisubject, task.done_status if has_trans else task.missing_status)
+                    elif task.name == 'ica':
+                        ctx = pipeline._resolve_derivative(ica_input_name(raw_name))
+                        spec = JobSpec(ctx)
+                        status = ctx.load(view='status')
+                        if status == 'ok':
+                            try:
+                                ica = ctx.load()
+                                row = (*combo, task.done_status, *task.result_columns(ica))
+                            except ProtectedArtifactError as error:
+                                if bulk_choice is None:
+                                    choice, apply_to_all = self._ask_stale_ica(combo[0], error, allow_apply_to_all=True)
+                                    if apply_to_all:
+                                        bulk_choice = choice
+                                else:
+                                    choice = bulk_choice
+                                row = self._handle_stale_ica(combo, scope, error, choice)
+                        elif status == 'missing-ica':
+                            row = task.missing_row(combo, layout)
+                        else:
+                            row = task.missing_row(combo, layout, 'no data')
 
-                yield combo, row, spec
+                    elif task.name == 'epoch_rej':
+                        rej = pipeline._epoch_rejection[epoch_rejection]
+                        node_name = 'epoch-rejection-input' if isinstance(rej, ManualRejection) else 'epoch-rejection-channel-model'
+                        rej_ctx = pipeline._resolve_derivative(node_name)
+                        if isinstance(rej, ManualRejection):
+                            path = rej_ctx.node.path(rej_ctx)  # an input, with no resolved artifact path
+                        else:
+                            spec = JobSpec(rej_ctx)
+                            # Existence, not spec.is_done: validating (or rebuilding) every
+                            # subject's rejection file on each refresh would be far too expensive.
+                            path = spec.path
+                        if path.exists():
+                            ds = load.unpickle(path)
+                            row = (*combo, task.done_status, *task.result_columns(ds))
+                        else:
+                            row = task.missing_row(combo, layout)
+
+                    elif task.name == 'mri':
+                        subjects_dir = pipeline.root / MRI_SDIR
+                        if combo == (COMMON_BRAIN_ROW,):
+                            mrisubject = pipeline.get('common_brain')
+                            has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
+                            status = task.done_status if has_recon else COMMON_BRAIN_MISSING
+                        else:
+                            mrisubject = pipeline.get('mrisubject')
+                            has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
+                            if has_recon:
+                                status = 'template' if is_fake_mri(subjects_dir / mrisubject) else task.done_status
+                            else:
+                                status = task.missing_status
+                        row = (*combo, mrisubject, status)
+
+                    elif task.name == 'coreg':
+                        mrisubject = pipeline.get('mrisubject')
+                        trans_ctx = pipeline._resolve_derivative('trans-input')
+                        has_trans = trans_ctx.node.exists(trans_ctx)
+                        row = (*combo, mrisubject, task.done_status if has_trans else task.missing_status)
+
+                except _AbortRequested:
+                    raise
+                except Exception as exc:
+                    row, spec, error = task.missing_row(combo, layout, ERROR), None, exc
+                yield combo, row, spec, error

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -89,10 +89,10 @@ def _timed_rows(
 ) -> Iterator:
     """Yield ``combos``, logging at DEBUG level how long the consumer spends on each one.
 
-    Every branch of :meth:`PipelineFrame._compute_rows` builds its table by looping over
-    ``Pipeline.iter()``, so the interval between two yields is the work that goes into
-    one table row: wrapping the iterator times all of them without instrumenting each
-    branch separately. Visible on the terminal with ``eelbrain-gui --debug``.
+    :meth:`PipelineFrame._iter_rows` builds its table by looping over
+    :meth:`PipelineFrame._iter_combos`, so the interval between two yields is the work
+    that goes into one table row, whichever task's branch produced it. Visible on the
+    terminal with ``eelbrain-gui --debug``.
 
     Parameters
     ----------
@@ -163,6 +163,9 @@ COMMON_BRAIN_MISSING = 'missing'
 # Statuses written by the compute queue while a row is in flight: the artifact
 # is not there yet, so they count as missing in the status bar
 TRANSIENT_STATUS = ('queued', '⟳')
+# Status of a row whose artifact has not been looked at yet: the first pass of a
+# refresh lays out the table, the second fills these in (see PipelineFrame._refresh_thread)
+LOADING = '…'
 # Stands in for a detail column that has no value because the artifact is missing
 PLACEHOLDER = '—'
 GREY = wx.Colour(150, 150, 150)
@@ -307,7 +310,10 @@ class Task:
         raise NotImplementedError(f"{self.name} is not computable")
 
     def missing_row(self, combo: tuple[str, ...], layout: Layout, status: str | None = None) -> tuple[str, ...]:
-        """Row for a key combination with no artifact: status plus placeholders.
+        """Row for a key combination with no artifact to show: status plus placeholders.
+
+        Also the row of the first refresh pass, whose status is not known yet
+        (``status=LOADING``; see :meth:`PipelineFrame._refresh_thread`).
 
         Parameters
         ----------
@@ -541,13 +547,13 @@ class PipelineFrame(EelbrainFrame):
         self._job_queue_lock = threading.Lock()
         self._n_done = self._n_total = 0  # progress of the current run
         # Job specs for the rows currently displayed, keyed by (scope, combo). Minted
-        # during refresh (where pipeline.iter() sets the state) and replaced wholesale
-        # by _populate_table; the scope is part of the key because a combo only names a
-        # row within one table (see :meth:`_table_scope`), and a lookup can outlive the
-        # table it was minted for (_on_ica_bad_channels runs when a separate window
-        # closes). A spec holds no data, only the state it was resolved with, so it stays
-        # usable after the inputs change: make_job() re-resolves dependencies live at
-        # that point.
+        # during refresh (where pipeline.iter() sets the state), cleared for the new table
+        # by _populate_table and filled in row by row by _fill_row. The scope is part of
+        # the key because a combo only names a row within one table (see
+        # :meth:`_table_scope`), and a lookup can outlive the table it was minted for
+        # (_on_ica_bad_channels runs when a separate window closes). A spec holds no data,
+        # only the state it was resolved with, so it stays usable after the inputs change:
+        # make_job() re-resolves dependencies live at that point.
         self._job_specs: dict[tuple[tuple, tuple], JobSpec] = {}
         self._tasks: list[Task] = []  # dropdown entries, in order
         # Column geometry of the displayed table, read by everything that addresses a
@@ -680,7 +686,7 @@ class PipelineFrame(EelbrainFrame):
         """Identity of the table on display: ``(task, epoch_rejection, epoch, raw, layout)``.
 
         Every choice that selects which rows are shown, and the arguments
-        :meth:`_compute_rows` needs to produce them. A row ``combo`` only names a
+        :meth:`_iter_combos` and :meth:`_iter_rows` need to produce them. A row ``combo`` only names a
         row within one scope, so a job minted for one table is never applied to a
         row of another: the Raw, Epoch and Epoch-rejection choices stay enabled
         while a computation runs, and switching one of them (or the number of ICA
@@ -1068,18 +1074,47 @@ class PipelineFrame(EelbrainFrame):
             self._list.SetItem(idx, col, value)
         self._set_row_colour(idx, self._row(idx))
 
-    def _populate_table(self, rows: list[tuple[str, ...]], specs: dict[tuple, JobSpec], token: object) -> None:
+    def _populate_table(self, rows: list[tuple[str, ...]], token: object) -> None:
+        """Install the rows of a new table, with their status still to be filled in."""
         if token is not self._refresh_token:
             return
-        # Only writer of _job_specs, on the main thread and behind the token guard, so a
-        # raw/task switch can never leave a spec from the previous table behind.
-        self._job_specs = specs
+        # Clears the specs of the previous table; _fill_row adds this table's as its rows
+        # resolve. Both run on the main thread and behind the token guard, so a raw/task
+        # switch can never leave a spec from the previous table behind.
+        self._job_specs = {}
         self._list.DeleteAllItems()
         for row in rows:
             idx = self._list.InsertItem(self._list.GetItemCount(), row[0])
             for col, val in enumerate(row[1:], 1):
                 self._list.SetItem(idx, col, val)
             self._set_row_colour(idx, row)
+        self._refresh_status_bar()
+
+    def _fill_row(
+            self,
+            token: object,
+            scope: tuple,  # see :meth:`_table_scope`
+            index: int,
+            combo: tuple[str, ...],
+            row: tuple[str, ...],
+            spec: JobSpec | None,
+    ) -> None:
+        """Replace one loading row with the status and details the refresh found for it.
+
+        ``index`` is where :meth:`_populate_table` put the row: both passes of the
+        refresh walk the same combinations in the same order, and ``token`` guarantees
+        the table on display is still the one they were walked for. The combo is
+        verified all the same, so a row can never be given another recording's status.
+        """
+        if token is not self._refresh_token:
+            return
+        if index >= self._list.GetItemCount() or self._row_combo(index) != combo:
+            return
+        if spec is not None:
+            self._job_specs[scope, combo] = spec
+        for col, value in enumerate(row):
+            self._list.SetItem(index, col, value)
+        self._set_row_colour(index, row)
         self._refresh_status_bar()
 
     def _update_ica_row(self, scope: tuple, combo: tuple, doc) -> None:
@@ -1091,9 +1126,17 @@ class PipelineFrame(EelbrainFrame):
         self._refresh_status_bar()
 
     def _refresh_status_bar(self):
-        """Recompute the status bar summary from the current table contents."""
+        """Recompute the status bar summary from the current table contents.
+
+        While the second pass of a refresh is still filling rows in, the summary would
+        undercount, so the progress of that pass is shown instead.
+        """
         rows = [self._row(i) for i in range(self._list.GetItemCount())]
-        self.SetStatusText(self._current_task().status_bar(rows, self._layout))
+        n_loading = sum(1 for row in rows if row[self._layout.status_col] == LOADING)
+        if n_loading:
+            self.SetStatusText(f"Loading… {len(rows) - n_loading} / {len(rows)}")
+        else:
+            self.SetStatusText(self._current_task().status_bar(rows, self._layout))
 
     # ------------------------------------------------------------------
     # Background status refresh
@@ -1125,21 +1168,41 @@ class PipelineFrame(EelbrainFrame):
             token: object,
             scope: tuple,  # see :meth:`_table_scope`
     ) -> None:
+        """Fill the table in two passes: which rows it has, then what is in them.
+
+        The first pass reads only the pipeline's state model and the BIDS dataset, so
+        the table is on screen before any artifact is opened; the second pass posts
+        every row as soon as its status resolves, which for the ICA task takes a raw
+        file read per recording. Both passes hold the pipeline lock, so neither ever
+        walks the pipeline while the compute worker is using it.
+        """
+        task, _, _, _, layout = scope
         log = self._pipeline._log
+        n_filled = 0
         t_start = time.time()
         try:
             with self._pipeline_lock:
                 t_locked = time.time()
-                rows, specs = self._compute_rows(token, scope)
+                combos = list(self._iter_combos(scope))
+            # A refresh that is queued behind a running computation waits for the lock,
+            # so the two intervals are logged separately (see eelbrain-gui --debug)
+            log.debug(f"Pipeline GUI {task.name}: {len(combos)} rows in {time.time() - t_locked:.3f} s, after waiting {t_locked - t_start:.3f} s for the pipeline")
+            if token is not self._refresh_token:
+                return  # the table was replaced while the rows were being determined
+            wx.CallAfter(self._populate_table, [task.missing_row(combo, layout, LOADING) for combo in combos], token)
+
+            t_start = time.time()
+            with self._pipeline_lock:
+                t_locked = time.time()
+                for index, (combo, row, spec) in enumerate(self._iter_rows(token, scope)):
+                    wx.CallAfter(self._fill_row, token, scope, index, combo, row, spec)
+                    n_filled += 1
         except _AbortRequested:
             return  # app exit already scheduled
         except Exception as error:
             wx.CallAfter(self._show_error, *_error_dialog_args(error))
             return
-        # A refresh that is queued behind a running computation waits for the lock, so
-        # the two intervals are logged separately (see eelbrain-gui --debug)
-        log.debug(f"Pipeline GUI {scope[0].name}: {len(rows)} rows in {time.time() - t_locked:.3f} s, after waiting {t_locked - t_start:.3f} s for the pipeline")
-        wx.CallAfter(self._populate_table, rows, specs, token)
+        log.debug(f"Pipeline GUI {task.name}: {n_filled} row details in {time.time() - t_locked:.3f} s, after waiting {t_locked - t_start:.3f} s for the pipeline")
 
     def _show_error(self, tb: str, title: str = "Error", message: str | None = None):
         self.SetStatusText("Error")
@@ -1566,113 +1629,130 @@ class PipelineFrame(EelbrainFrame):
         else:
             self._start_refresh()
 
-    def _compute_rows(
+    def _iter_combos(
             self,
-            token: object,
             scope: tuple,  # see :meth:`_table_scope`
-    ) -> tuple[list[tuple[str, ...]], dict[tuple[tuple, tuple], JobSpec]]:
+    ) -> Iterator[tuple[str, ...]]:
+        """Iterate the table's rows, setting the pipeline state for each one.
+
+        First pass of a refresh: which rows the table has follows from the pipeline's
+        state model and, for the tasks whose rows are recordings, from which files the
+        BIDS dataset actually holds -- neither of which requires opening an artifact.
+        The second pass (:meth:`_iter_rows`) walks the same combinations in the same
+        order, so a row's position identifies it in both.
+        """
         task, epoch_rejection, epoch_name, raw_name, layout = scope
         pipeline = self._pipeline
-        log = pipeline._log
-        rows = []
-        specs: dict[tuple[tuple, tuple], JobSpec] = {}
-
-        if task.name == 'bad_chs':
-            source_name = pipeline._raw.root_source_name(raw_name)
-            for combo in _timed_rows(pipeline.iter(layout.iter_arg), log, task.name):
-                if token is not self._refresh_token:
-                    break
-                if isinstance(combo, str):
-                    combo = (combo,)
+        if task.name == 'epoch_rej':
+            combos = pipeline.iter(layout.iter_arg, raw=raw_name, epoch=epoch_name, epoch_rejection=epoch_rejection)
+        elif task.name == 'coreg':
+            combos = pipeline.iter(layout.iter_arg, raw='raw')
+        else:
+            combos = pipeline.iter(layout.iter_arg)
+        # the tasks that show one row per recording skip recordings that were never acquired
+        source_name = pipeline._raw.root_source_name(raw_name) if task.name == 'bad_chs' else 'raw'
+        skip_missing_recordings = task.name in ('bad_chs', 'coreg')
+        for combo in combos:
+            if isinstance(combo, str):
+                combo = (combo,)
+            if skip_missing_recordings:
                 raw_ctx = pipeline._resolve_derivative(raw_input_name(source_name))
                 if not raw_ctx.node.exists(raw_ctx):
                     continue
+            yield combo
+        # Common brain row at the bottom of the MRI table; not a subject, and outside the
+        # iteration, so the pipeline state is the one it was left in
+        if task.name == 'mri' and pipeline.get('common_brain'):
+            yield (COMMON_BRAIN_ROW,)
+
+    def _iter_rows(
+            self,
+            token: object,
+            scope: tuple,  # see :meth:`_table_scope`
+    ) -> Iterator[tuple[tuple[str, ...], tuple[str, ...], JobSpec | None]]:
+        """Yield ``(combo, row, job spec)`` for every row of the table.
+
+        Second pass of a refresh: this is where a row's artifact is inspected, which for
+        the ICA task means validating it against the raw data it was estimated from --
+        one raw file per recording. Rows are therefore yielded one at a time, so that
+        the caller can show each as soon as it resolves. ``spec`` is ``None`` for a row
+        whose artifact the compute queue cannot make.
+        """
+        task, epoch_rejection, epoch_name, raw_name, layout = scope
+        pipeline = self._pipeline
+        bulk_choice = None  # set once the user ticks "Apply to all" in the stale-ICA dialog
+        for combo in _timed_rows(self._iter_combos(scope), pipeline._log, task.name):
+            if token is not self._refresh_token:
+                return
+            spec = None
+
+            if task.name == 'bad_chs':
+                source_name = pipeline._raw.root_source_name(raw_name)
                 bads_ctx = pipeline._resolve_derivative(raw_bad_channels_input_name(source_name))
                 try:
                     bads = bads_ctx.load()  # seeds a missing derivatives channels.tsv
                 except DataError:  # EEG channels without positions
-                    rows.append(task.missing_row(combo, layout))
+                    row = task.missing_row(combo, layout)
                 else:
-                    rows.append((*combo, task.done_status, str(len(bads))))
+                    row = (*combo, task.done_status, str(len(bads)))
 
-        elif task.name == 'ica':
-            bulk_choice = None  # set once the user ticks "Apply to all"
-            for combo in _timed_rows(pipeline.iter(layout.iter_arg), log, task.name):
-                if token is not self._refresh_token:
-                    break
-                if isinstance(combo, str):
-                    combo = (combo,)
-                subject = combo[0]
+            elif task.name == 'ica':
                 ctx = pipeline._resolve_derivative(ica_input_name(raw_name))
-                specs[scope, combo] = JobSpec(ctx)
+                spec = JobSpec(ctx)
                 status = ctx.load(view='status')
                 if status == 'ok':
                     try:
                         ica = ctx.load()
-                        rows.append((*combo, task.done_status, *task.result_columns(ica)))
+                        row = (*combo, task.done_status, *task.result_columns(ica))
                     except ProtectedArtifactError as error:
                         if bulk_choice is None:
-                            choice, apply_to_all = self._ask_stale_ica(subject, error, allow_apply_to_all=True)
+                            choice, apply_to_all = self._ask_stale_ica(combo[0], error, allow_apply_to_all=True)
                             if apply_to_all:
                                 bulk_choice = choice
                         else:
                             choice = bulk_choice
-                        rows.append(self._handle_stale_ica(combo, scope, error, choice))
+                        row = self._handle_stale_ica(combo, scope, error, choice)
                 elif status == 'missing-ica':
-                    rows.append(task.missing_row(combo, layout))
+                    row = task.missing_row(combo, layout)
                 else:
-                    rows.append(task.missing_row(combo, layout, 'no data'))
+                    row = task.missing_row(combo, layout, 'no data')
 
-        elif task.name == 'epoch_rej':
-            rej = pipeline._epoch_rejection[epoch_rejection]
-            node_name = 'epoch-rejection-input' if isinstance(rej, ManualRejection) else 'epoch-rejection-channel-model'
-            combos = pipeline.iter(layout.iter_arg, raw=raw_name, epoch=epoch_name, epoch_rejection=epoch_rejection)
-            for subject in _timed_rows(combos, log, task.name):
-                if token is not self._refresh_token:
-                    break
+            elif task.name == 'epoch_rej':
+                rej = pipeline._epoch_rejection[epoch_rejection]
+                node_name = 'epoch-rejection-input' if isinstance(rej, ManualRejection) else 'epoch-rejection-channel-model'
                 rej_ctx = pipeline._resolve_derivative(node_name)
                 if isinstance(rej, ManualRejection):
                     path = rej_ctx.node.path(rej_ctx)  # an input, with no resolved artifact path
                 else:
-                    spec = specs[scope, (subject,)] = JobSpec(rej_ctx)
+                    spec = JobSpec(rej_ctx)
                     # Existence, not spec.is_done: validating (or rebuilding) every
                     # subject's rejection file on each refresh would be far too expensive.
                     path = spec.path
                 if path.exists():
                     ds = load.unpickle(path)
-                    rows.append((subject, task.done_status, *task.result_columns(ds)))
+                    row = (*combo, task.done_status, *task.result_columns(ds))
                 else:
-                    rows.append(task.missing_row((subject,), layout))
+                    row = task.missing_row(combo, layout)
 
-        elif task.name == 'mri':
-            subjects_dir = pipeline.root / MRI_SDIR
-            for subject in _timed_rows(pipeline.iter(layout.iter_arg), log, task.name):
-                if token is not self._refresh_token:
-                    break
-                mrisubject = pipeline.get('mrisubject')
-                has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
-                if has_recon:
-                    status = 'template' if is_fake_mri(subjects_dir / mrisubject) else task.done_status
+            elif task.name == 'mri':
+                subjects_dir = pipeline.root / MRI_SDIR
+                if combo == (COMMON_BRAIN_ROW,):
+                    mrisubject = pipeline.get('common_brain')
+                    has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
+                    status = task.done_status if has_recon else COMMON_BRAIN_MISSING
                 else:
-                    status = task.missing_status
-                rows.append((subject, mrisubject, status))
-            # Common brain row at the bottom
-            common_brain = pipeline.get('common_brain')
-            if common_brain:
-                has_cb = (subjects_dir / common_brain / 'surf' / 'lh.pial').exists()
-                rows.append((COMMON_BRAIN_ROW, common_brain, task.done_status if has_cb else COMMON_BRAIN_MISSING))
+                    mrisubject = pipeline.get('mrisubject')
+                    has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
+                    if has_recon:
+                        status = 'template' if is_fake_mri(subjects_dir / mrisubject) else task.done_status
+                    else:
+                        status = task.missing_status
+                row = (*combo, mrisubject, status)
 
-        elif task.name == 'coreg':
-            raw_input = raw_input_name('raw')
-            for subject, session in _timed_rows(pipeline.iter(layout.iter_arg, raw='raw'), log, task.name):
-                if token is not self._refresh_token:
-                    break
-                raw_ctx = pipeline._resolve_derivative(raw_input)
-                if not raw_ctx.node.exists(raw_ctx):
-                    continue
+            elif task.name == 'coreg':
                 mrisubject = pipeline.get('mrisubject')
                 trans_ctx = pipeline._resolve_derivative('trans-input')
                 has_trans = trans_ctx.node.exists(trans_ctx)
-                rows.append((subject, session, mrisubject, task.done_status if has_trans else task.missing_status))
+                row = (*combo, mrisubject, task.done_status if has_trans else task.missing_status)
 
-        return rows, specs
+            yield combo, row, spec

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -842,8 +842,8 @@ class PipelineFrame(EelbrainFrame):
 
     def _on_item_right_click(self, event):
         """Row right-click: context menu (Bad channels task only)."""
-        if self._current_task().name != 'bad_chs':
-            return
+        if self._current_task().name != 'bad_chs' or self._n_loading:
+            return  # while rows are loading, the refresh thread is using the pipeline (see _activate_row)
         idx = event.GetIndex()
         if idx == wx.NOT_FOUND:
             return
@@ -891,8 +891,10 @@ class PipelineFrame(EelbrainFrame):
 
     def _activate_row(self, idx: int) -> None:
         """Perform the double-click action for the row at ``idx``."""
-        if self._list.GetItemText(idx, self._layout.status_col) == LOADING:
-            return  # the row's columns are still placeholders (see _refresh_thread)
+        if self._n_loading:
+            # The refresh thread is still setting the pipeline's state row by row (see
+            # _iter_rows), which an action on the main thread would interleave with
+            return
         subject = self._list.GetItemText(idx, 0)
         task = self._current_task()
         # Loop so that after the user incorporates a stale ICA we can retry the

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -1799,14 +1799,14 @@ class PipelineFrame(EelbrainFrame):
                             try:
                                 ica = ctx.load()
                                 row = (*combo, task.done_status, *task.result_columns(ica))
-                            except ProtectedArtifactError as error:
+                            except ProtectedArtifactError as stale:  # not ``error``: the name is unbound after the block, but yielded below
                                 if bulk_choice is None:
-                                    choice, apply_to_all = self._ask_stale_ica(combo[0], error, allow_apply_to_all=True)
+                                    choice, apply_to_all = self._ask_stale_ica(combo[0], stale, allow_apply_to_all=True)
                                     if apply_to_all:
                                         bulk_choice = choice
                                 else:
                                     choice = bulk_choice
-                                row = self._handle_stale_ica(combo, scope, error, choice)
+                                row = self._handle_stale_ica(combo, scope, stale, choice)
                         elif status == 'missing-ica':
                             row = task.missing_row(combo, layout)
                         else:

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -1096,10 +1096,10 @@ class PipelineFrame(EelbrainFrame):
     ) -> None:
         """Replace one loading row with the status and details the refresh found for it.
 
-        ``index`` is where :meth:`_populate_table` put the row: both passes of the
-        refresh walk the same combinations in the same order, and ``token`` guarantees
-        the table on display is still the one they were walked for. The combo is
-        verified all the same, so a row can never be given another recording's status.
+        ``index`` is where :meth:`_populate_table` put the row: the second pass of the
+        refresh resolves the rows the first pass found, in order, and ``token``
+        guarantees the table on display is still the one they were found for. The combo
+        is verified all the same, so a row can never be given another recording's status.
         """
         if token is not self._refresh_token:
             return
@@ -1189,7 +1189,7 @@ class PipelineFrame(EelbrainFrame):
             t_start = time.time()
             with self._pipeline_lock:
                 t_locked = time.time()
-                for index, (combo, row, spec) in enumerate(self._iter_rows(token, scope)):
+                for index, (combo, row, spec) in enumerate(self._iter_rows(token, scope, combos)):
                     wx.CallAfter(self._fill_row, token, scope, index, combo, row, spec)
                     n_filled += 1
         except _AbortRequested:
@@ -1639,17 +1639,11 @@ class PipelineFrame(EelbrainFrame):
         First pass of a refresh: which rows the table has follows from the pipeline's
         state model and, for the tasks whose rows are recordings, from which files the
         BIDS dataset actually holds -- neither of which requires opening an artifact.
-        The second pass (:meth:`_iter_rows`) walks the same combinations in the same
-        order, so a row's position identifies it in both.
+        The second pass (:meth:`_iter_rows`) is over the list this produced.
         """
-        task, epoch_rejection, epoch_name, raw_name, layout = scope
+        task, _, _, raw_name, layout = scope
         pipeline = self._pipeline
-        if task.name == 'epoch_rej':
-            combos = pipeline.iter(list(layout.key_fields), raw=raw_name, epoch=epoch_name, epoch_rejection=epoch_rejection)
-        elif task.name == 'coreg':
-            combos = pipeline.iter(list(layout.key_fields), raw='raw')
-        else:
-            combos = pipeline.iter(list(layout.key_fields))
+        combos = pipeline.iter(list(layout.key_fields), **self._iter_state(scope))
         # the tasks that show one row per recording skip recordings that were never acquired
         source_name = pipeline._raw.root_source_name(raw_name) if task.name == 'bad_chs' else 'raw'
         skip_missing_recordings = task.name in ('bad_chs', 'coreg')
@@ -1664,94 +1658,118 @@ class PipelineFrame(EelbrainFrame):
         if task.name == 'mri' and pipeline.get('common_brain'):
             yield (COMMON_BRAIN_ROW,)
 
+    def _iter_state(self, scope: tuple) -> dict[str, str]:
+        """State every row of the table is resolved under, besides its key fields."""
+        task, epoch_rejection, epoch_name, raw_name, _ = scope
+        if task.name == 'epoch_rej':
+            return {'raw': raw_name, 'epoch': epoch_name, 'epoch_rejection': epoch_rejection}
+        elif task.name == 'coreg':
+            return {'raw': 'raw'}
+        return {}
+
     def _iter_rows(
             self,
             token: object,
             scope: tuple,  # see :meth:`_table_scope`
+            combos: Sequence[tuple[str, ...]],
     ) -> Iterator[tuple[tuple[str, ...], tuple[str, ...], JobSpec | None]]:
         """Yield ``(combo, row, job spec)`` for every row of the table.
 
-        Second pass of a refresh: this is where a row's artifact is inspected, which for
-        the ICA task means validating it against the raw data it was estimated from --
-        one raw file per recording. Rows are therefore yielded one at a time, so that
-        the caller can show each as soon as it resolves. ``spec`` is ``None`` for a row
-        whose artifact the compute queue cannot make.
+        Second pass of a refresh, over the rows the first pass found: this is where a
+        row's artifact is inspected, which for the ICA task means validating it against
+        the raw data it was estimated from -- one raw file per recording. Rows are
+        therefore yielded one at a time, so that the caller can show each as soon as it
+        resolves. ``spec`` is ``None`` for a row whose artifact the compute queue cannot
+        make.
+
+        Parameters
+        ----------
+        token
+            Refresh this pass belongs to; the pass stops once it is superseded.
+        scope
+            Table the rows belong to (see :meth:`_table_scope`).
+        combos
+            Rows to resolve, as :meth:`_iter_combos` yielded them.
         """
-        task, epoch_rejection, epoch_name, raw_name, layout = scope
+        task, epoch_rejection, _, raw_name, layout = scope
         pipeline = self._pipeline
+        constants = self._iter_state(scope)
         bulk_choice = None  # set once the user ticks "Apply to all" in the stale-ICA dialog
-        for combo in _timed_rows(self._iter_combos(scope), pipeline._log, task.name):
-            if token is not self._refresh_token:
-                return
-            spec = None
+        with pipeline._temporary_state:
+            for combo in _timed_rows(combos, pipeline._log, task.name):
+                if token is not self._refresh_token:
+                    return
+                if combo != (COMMON_BRAIN_ROW,):
+                    pipeline.set(**constants, **dict(zip(layout.key_fields, combo)))
+                spec = None
 
-            if task.name == 'bad_chs':
-                source_name = pipeline._raw.root_source_name(raw_name)
-                bads_ctx = pipeline._resolve_derivative(raw_bad_channels_input_name(source_name))
-                try:
-                    bads = bads_ctx.load()  # seeds a missing derivatives channels.tsv
-                except DataError:  # EEG channels without positions
-                    row = task.missing_row(combo, layout)
-                else:
-                    row = (*combo, task.done_status, str(len(bads)))
-
-            elif task.name == 'ica':
-                ctx = pipeline._resolve_derivative(ica_input_name(raw_name))
-                spec = JobSpec(ctx)
-                status = ctx.load(view='status')
-                if status == 'ok':
+                if task.name == 'bad_chs':
+                    source_name = pipeline._raw.root_source_name(raw_name)
+                    bads_ctx = pipeline._resolve_derivative(raw_bad_channels_input_name(source_name))
                     try:
-                        ica = ctx.load()
-                        row = (*combo, task.done_status, *task.result_columns(ica))
-                    except ProtectedArtifactError as error:
-                        if bulk_choice is None:
-                            choice, apply_to_all = self._ask_stale_ica(combo[0], error, allow_apply_to_all=True)
-                            if apply_to_all:
-                                bulk_choice = choice
-                        else:
-                            choice = bulk_choice
-                        row = self._handle_stale_ica(combo, scope, error, choice)
-                elif status == 'missing-ica':
-                    row = task.missing_row(combo, layout)
-                else:
-                    row = task.missing_row(combo, layout, 'no data')
-
-            elif task.name == 'epoch_rej':
-                rej = pipeline._epoch_rejection[epoch_rejection]
-                node_name = 'epoch-rejection-input' if isinstance(rej, ManualRejection) else 'epoch-rejection-channel-model'
-                rej_ctx = pipeline._resolve_derivative(node_name)
-                if isinstance(rej, ManualRejection):
-                    path = rej_ctx.node.path(rej_ctx)  # an input, with no resolved artifact path
-                else:
-                    spec = JobSpec(rej_ctx)
-                    # Existence, not spec.is_done: validating (or rebuilding) every
-                    # subject's rejection file on each refresh would be far too expensive.
-                    path = spec.path
-                if path.exists():
-                    ds = load.unpickle(path)
-                    row = (*combo, task.done_status, *task.result_columns(ds))
-                else:
-                    row = task.missing_row(combo, layout)
-
-            elif task.name == 'mri':
-                subjects_dir = pipeline.root / MRI_SDIR
-                if combo == (COMMON_BRAIN_ROW,):
-                    mrisubject = pipeline.get('common_brain')
-                    has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
-                    status = task.done_status if has_recon else COMMON_BRAIN_MISSING
-                else:
-                    mrisubject = pipeline.get('mrisubject')
-                    has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
-                    if has_recon:
-                        status = 'template' if is_fake_mri(subjects_dir / mrisubject) else task.done_status
+                        bads = bads_ctx.load()  # seeds a missing derivatives channels.tsv
+                    except DataError:  # EEG channels without positions
+                        row = task.missing_row(combo, layout)
                     else:
-                        status = task.missing_status
-                row = (*combo, mrisubject, status)
+                        row = (*combo, task.done_status, str(len(bads)))
 
-            elif task.name == 'coreg':
-                mrisubject = pipeline.get('mrisubject')
-                trans_ctx = pipeline._resolve_derivative('trans-input')
-                has_trans = trans_ctx.node.exists(trans_ctx)
-                row = (*combo, mrisubject, task.done_status if has_trans else task.missing_status)
+                elif task.name == 'ica':
+                    ctx = pipeline._resolve_derivative(ica_input_name(raw_name))
+                    spec = JobSpec(ctx)
+                    status = ctx.load(view='status')
+                    if status == 'ok':
+                        try:
+                            ica = ctx.load()
+                            row = (*combo, task.done_status, *task.result_columns(ica))
+                        except ProtectedArtifactError as error:
+                            if bulk_choice is None:
+                                choice, apply_to_all = self._ask_stale_ica(combo[0], error, allow_apply_to_all=True)
+                                if apply_to_all:
+                                    bulk_choice = choice
+                            else:
+                                choice = bulk_choice
+                            row = self._handle_stale_ica(combo, scope, error, choice)
+                    elif status == 'missing-ica':
+                        row = task.missing_row(combo, layout)
+                    else:
+                        row = task.missing_row(combo, layout, 'no data')
 
-            yield combo, row, spec
+                elif task.name == 'epoch_rej':
+                    rej = pipeline._epoch_rejection[epoch_rejection]
+                    node_name = 'epoch-rejection-input' if isinstance(rej, ManualRejection) else 'epoch-rejection-channel-model'
+                    rej_ctx = pipeline._resolve_derivative(node_name)
+                    if isinstance(rej, ManualRejection):
+                        path = rej_ctx.node.path(rej_ctx)  # an input, with no resolved artifact path
+                    else:
+                        spec = JobSpec(rej_ctx)
+                        # Existence, not spec.is_done: validating (or rebuilding) every
+                        # subject's rejection file on each refresh would be far too expensive.
+                        path = spec.path
+                    if path.exists():
+                        ds = load.unpickle(path)
+                        row = (*combo, task.done_status, *task.result_columns(ds))
+                    else:
+                        row = task.missing_row(combo, layout)
+
+                elif task.name == 'mri':
+                    subjects_dir = pipeline.root / MRI_SDIR
+                    if combo == (COMMON_BRAIN_ROW,):
+                        mrisubject = pipeline.get('common_brain')
+                        has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
+                        status = task.done_status if has_recon else COMMON_BRAIN_MISSING
+                    else:
+                        mrisubject = pipeline.get('mrisubject')
+                        has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
+                        if has_recon:
+                            status = 'template' if is_fake_mri(subjects_dir / mrisubject) else task.done_status
+                        else:
+                            status = task.missing_status
+                    row = (*combo, mrisubject, status)
+
+                elif task.name == 'coreg':
+                    mrisubject = pipeline.get('mrisubject')
+                    trans_ctx = pipeline._resolve_derivative('trans-input')
+                    has_trans = trans_ctx.node.exists(trans_ctx)
+                    row = (*combo, mrisubject, task.done_status if has_trans else task.missing_status)
+
+                yield combo, row, spec

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -192,11 +192,6 @@ class Layout:
     columns: tuple[tuple[str, int], ...]
     status_col: int
 
-    @property
-    def iter_arg(self) -> str | list[str]:
-        """``fields`` argument to :meth:`Pipeline.iter` yielding one entry per row."""
-        return self.key_fields[0] if len(self.key_fields) == 1 else list(self.key_fields)
-
 
 class Task:
     """Per-task presentation rules for the pipeline table.
@@ -1650,17 +1645,15 @@ class PipelineFrame(EelbrainFrame):
         task, epoch_rejection, epoch_name, raw_name, layout = scope
         pipeline = self._pipeline
         if task.name == 'epoch_rej':
-            combos = pipeline.iter(layout.iter_arg, raw=raw_name, epoch=epoch_name, epoch_rejection=epoch_rejection)
+            combos = pipeline.iter(list(layout.key_fields), raw=raw_name, epoch=epoch_name, epoch_rejection=epoch_rejection)
         elif task.name == 'coreg':
-            combos = pipeline.iter(layout.iter_arg, raw='raw')
+            combos = pipeline.iter(list(layout.key_fields), raw='raw')
         else:
-            combos = pipeline.iter(layout.iter_arg)
+            combos = pipeline.iter(list(layout.key_fields))
         # the tasks that show one row per recording skip recordings that were never acquired
         source_name = pipeline._raw.root_source_name(raw_name) if task.name == 'bad_chs' else 'raw'
         skip_missing_recordings = task.name in ('bad_chs', 'coreg')
         for combo in combos:
-            if isinstance(combo, str):
-                combo = (combo,)
             if skip_missing_recordings:
                 raw_ctx = pipeline._resolve_derivative(raw_input_name(source_name))
                 if not raw_ctx.node.exists(raw_ctx):

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -218,7 +218,8 @@ class Task:
     status_width
         Width of the Status column.
     missing_status
-        Status of a row whose artifact has not been made yet.
+        Status of a row whose artifact has not been made yet; ``None`` for a
+        task whose artifact always exists.
     done_status
         Status of a row whose artifact is available.
     unit
@@ -367,6 +368,9 @@ class Task:
             if n_missing:
                 noun = f" {self.missing_note}" if self.missing_note else ''
                 msg += f"  ({n_missing} missing{noun})"
+        n_error = sum(1 for row in rows if row[layout.status_col] == ERROR)
+        if n_error:
+            msg += f"  ({n_error} error)"
         return msg
 
 
@@ -374,7 +378,6 @@ class BadChannelsTask(Task):
     name = 'bad_chs'
     label = "Bad channels"
     detail_columns = (('N bad', 90),)
-    missing_status = ERROR  # loading seeds a missing channels.tsv, so the only failure is bad data
     done_status = 'done'
     summary = "bad channels defined"
     recording_unit = 'recordings'
@@ -392,24 +395,6 @@ class BadChannelsTask(Task):
             if len(values) > 1:
                 fields.append(field)
         return tuple(fields)
-
-    def row_colour(
-            self,
-            row: tuple[str, ...],
-            layout: Layout,
-    ) -> wx.Colour | None:
-        return wx.RED if row[layout.status_col] == self.missing_status else None
-
-    def status_bar(
-            self,
-            rows: list[tuple[str, ...]],
-            layout: Layout,
-    ) -> str:
-        msg = super().status_bar(rows, layout)
-        n_error = sum(1 for row in rows if row[layout.status_col] == self.missing_status)
-        if n_error:
-            msg += f"  ({n_error} error)"
-        return msg
 
 
 class ICATask(Task):
@@ -1805,9 +1790,9 @@ class PipelineFrame(EelbrainFrame):
                         source_name = pipeline._raw.root_source_name(raw_name)
                         bads_ctx = pipeline._resolve_derivative(raw_bad_channels_input_name(source_name))
                         try:
-                            bads = bads_ctx.load()  # seeds a missing derivatives channels.tsv
+                            bads = bads_ctx.load()  # seeds a missing derivatives channels.tsv, so the only failure is bad data
                         except DataError:  # EEG channels without positions
-                            row = task.missing_row(combo, layout)
+                            row = task.missing_row(combo, layout, ERROR)
                         else:
                             row = (*combo, task.done_status, str(len(bads)))
 

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -774,6 +774,8 @@ class PipelineFrame(EelbrainFrame):
         if computable:
             self._compute_btn.SetLabel("Stop" if self._compute_token is not None else task.compute_label)
             self._compute_btn.SetToolTip(task.compute_tooltip)
+            # Computing waits until every row is in, so that one click queues every missing row; stopping never waits
+            self._compute_btn.Enable(self._compute_token is not None or not self._n_loading)
         self._compute_btn.Show(computable)
         self._panel.Layout()
 
@@ -1199,7 +1201,7 @@ class PipelineFrame(EelbrainFrame):
         else:
             rows = [self._row(i) for i in range(n)]
             self.SetStatusText(self._current_task().status_bar(rows, self._layout))
-        self._compute_btn.Enable(not self._n_loading)
+            self._update_compute_button()
 
     # ------------------------------------------------------------------
     # Background status refresh
@@ -1212,7 +1214,8 @@ class PipelineFrame(EelbrainFrame):
         self._list.DeleteAllItems()
         self._n_loading = 0
         self.SetStatusText("Loading…")
-        self._compute_btn.Disable()  # until every row is in, so that one click queues every missing row
+        if self._compute_token is None:  # during a computation the button is Stop, which a refresh must not block
+            self._compute_btn.Disable()
 
         if task.shows_epoch:
             if epoch_rejection is None:

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -1,9 +1,11 @@
 """Pipeline supervisor GUI launched by ``eelbrain-gui``."""
+import logging
 import subprocess
 import sys
 import threading
+import time
 import traceback
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -78,6 +80,35 @@ def _error_dialog_args(error: Exception) -> tuple[str, str, str | None]:
     if dialog is None:
         return tb, "Error", None
     return tb, *dialog
+
+
+def _timed_rows(
+        combos: Iterable,
+        log: logging.Logger,
+        label: str,
+) -> Iterator:
+    """Yield ``combos``, logging at DEBUG level how long the consumer spends on each one.
+
+    Every branch of :meth:`PipelineFrame._compute_rows` builds its table by looping over
+    ``Pipeline.iter()``, so the interval between two yields is the work that goes into
+    one table row: wrapping the iterator times all of them without instrumenting each
+    branch separately. Visible on the terminal with ``eelbrain-gui --debug``.
+
+    Parameters
+    ----------
+    combos
+        Key-field combinations from :meth:`Pipeline.iter`, one per table row.
+    log
+        Pipeline logger to write the timings to.
+    label
+        Task name, identifying which table the rows belong to.
+    """
+    t = time.time()
+    for i, combo in enumerate(combos):
+        yield combo
+        now = time.time()
+        log.debug(f"Pipeline GUI {label}: row {i} {combo} in {now - t:.3f} s")
+        t = now
 
 
 class BadChannelsDialog(wx.Dialog):
@@ -1094,14 +1125,20 @@ class PipelineFrame(EelbrainFrame):
             token: object,
             scope: tuple,  # see :meth:`_table_scope`
     ) -> None:
+        log = self._pipeline._log
+        t_start = time.time()
         try:
             with self._pipeline_lock:
+                t_locked = time.time()
                 rows, specs = self._compute_rows(token, scope)
         except _AbortRequested:
             return  # app exit already scheduled
         except Exception as error:
             wx.CallAfter(self._show_error, *_error_dialog_args(error))
             return
+        # A refresh that is queued behind a running computation waits for the lock, so
+        # the two intervals are logged separately (see eelbrain-gui --debug)
+        log.debug(f"Pipeline GUI {scope[0].name}: {len(rows)} rows in {time.time() - t_locked:.3f} s, after waiting {t_locked - t_start:.3f} s for the pipeline")
         wx.CallAfter(self._populate_table, rows, specs, token)
 
     def _show_error(self, tb: str, title: str = "Error", message: str | None = None):
@@ -1536,12 +1573,13 @@ class PipelineFrame(EelbrainFrame):
     ) -> tuple[list[tuple[str, ...]], dict[tuple[tuple, tuple], JobSpec]]:
         task, epoch_rejection, epoch_name, raw_name, layout = scope
         pipeline = self._pipeline
+        log = pipeline._log
         rows = []
         specs: dict[tuple[tuple, tuple], JobSpec] = {}
 
         if task.name == 'bad_chs':
             source_name = pipeline._raw.root_source_name(raw_name)
-            for combo in pipeline.iter(layout.iter_arg):
+            for combo in _timed_rows(pipeline.iter(layout.iter_arg), log, task.name):
                 if token is not self._refresh_token:
                     break
                 if isinstance(combo, str):
@@ -1559,7 +1597,7 @@ class PipelineFrame(EelbrainFrame):
 
         elif task.name == 'ica':
             bulk_choice = None  # set once the user ticks "Apply to all"
-            for combo in pipeline.iter(layout.iter_arg):
+            for combo in _timed_rows(pipeline.iter(layout.iter_arg), log, task.name):
                 if token is not self._refresh_token:
                     break
                 if isinstance(combo, str):
@@ -1588,8 +1626,8 @@ class PipelineFrame(EelbrainFrame):
         elif task.name == 'epoch_rej':
             rej = pipeline._epoch_rejection[epoch_rejection]
             node_name = 'epoch-rejection-input' if isinstance(rej, ManualRejection) else 'epoch-rejection-channel-model'
-            for subject in pipeline.iter(
-                    layout.iter_arg, raw=raw_name, epoch=epoch_name, epoch_rejection=epoch_rejection):
+            combos = pipeline.iter(layout.iter_arg, raw=raw_name, epoch=epoch_name, epoch_rejection=epoch_rejection)
+            for subject in _timed_rows(combos, log, task.name):
                 if token is not self._refresh_token:
                     break
                 rej_ctx = pipeline._resolve_derivative(node_name)
@@ -1608,7 +1646,7 @@ class PipelineFrame(EelbrainFrame):
 
         elif task.name == 'mri':
             subjects_dir = pipeline.root / MRI_SDIR
-            for subject in pipeline.iter(layout.iter_arg):
+            for subject in _timed_rows(pipeline.iter(layout.iter_arg), log, task.name):
                 if token is not self._refresh_token:
                     break
                 mrisubject = pipeline.get('mrisubject')
@@ -1626,7 +1664,7 @@ class PipelineFrame(EelbrainFrame):
 
         elif task.name == 'coreg':
             raw_input = raw_input_name('raw')
-            for subject, session in pipeline.iter(layout.iter_arg, raw='raw'):
+            for subject, session in _timed_rows(pipeline.iter(layout.iter_arg, raw='raw'), log, task.name):
                 if token is not self._refresh_token:
                     break
                 raw_ctx = pipeline._resolve_derivative(raw_input)

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -4,6 +4,7 @@ import sys
 import threading
 import traceback
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 
@@ -122,6 +123,358 @@ class BadChannelsDialog(wx.Dialog):
         return self._parse()
 
 
+# Row standing in for the common brain in the MRI table; not a subject
+COMMON_BRAIN_ROW = '(common brain)'
+# Status of the common brain row without a reconstruction. Distinct from
+# MRITask.missing_status because the row is not a subject: it is neither counted
+# nor coloured like one, and _on_mri_activated offers to download fsaverage for it.
+COMMON_BRAIN_MISSING = 'missing'
+# Statuses written by the compute queue while a row is in flight: the artifact
+# is not there yet, so they count as missing in the status bar
+TRANSIENT_STATUS = ('queued', '⟳')
+# Stands in for a detail column that has no value because the artifact is missing
+PLACEHOLDER = '—'
+GREY = wx.Colour(150, 150, 150)
+
+
+@dataclass(frozen=True)
+class Layout:
+    """Column geometry of the table for one task and Raw selection.
+
+    Resolved once per table by :meth:`Task.layout` and cached by
+    :class:`PipelineFrame`, so that the rows built off the main thread and the
+    columns they are written into can never disagree.
+
+    Attributes
+    ----------
+    key_fields
+        State fields identifying a row; their column values form its ``combo``.
+    columns
+        ``(title, width)`` for every column, in order.
+    status_col
+        Index of the Status column.
+    """
+    key_fields: tuple[str, ...]
+    columns: tuple[tuple[str, int], ...]
+    status_col: int
+
+    @property
+    def iter_arg(self) -> str | list[str]:
+        """``fields`` argument to :meth:`Pipeline.iter` yielding one entry per row."""
+        return self.key_fields[0] if len(self.key_fields) == 1 else list(self.key_fields)
+
+
+class Task:
+    """Per-task presentation rules for the pipeline table.
+
+    One instance per entry in the task dropdown, holding everything that varies
+    between tasks: which toolbar controls apply, the column layout, the status
+    vocabulary, the row colouring and the status-bar summary. Building the rows
+    and acting on a double-click stay in :class:`PipelineFrame`, which
+    dispatches on :attr:`name`.
+
+    Attributes
+    ----------
+    name
+        Internal key; also identifies the task in a job's scope (see
+        :meth:`PipelineFrame._table_scope`).
+    label
+        Entry in the task dropdown.
+    detail_columns
+        ``(title, width)`` for the columns after Status.
+    subject_width
+        Width of the leading Subject column.
+    status_width
+        Width of the Status column.
+    missing_status
+        Status of a row whose artifact has not been made yet.
+    done_status
+        Status of a row whose artifact is available.
+    unit
+        Noun for the status-bar count.
+    recording_unit
+        Noun for the status-bar count when the table has one row per recording
+        rather than per subject, i.e. when a key field beyond ``subject``
+        varies; ``None`` for tasks that always have one row per subject.
+    summary
+        Status-bar phrase after the count.
+    missing_note
+        Noun for the ``(N missing …)`` suffix; ``None`` omits the suffix, ``''``
+        gives a bare ``(N missing)``.
+    shows_raw
+        Whether the Raw dropdown applies.
+    shows_epoch
+        Whether the Epoch and Rejection dropdowns apply.
+    compute_label
+        Label for the compute button; ``None`` for tasks that only inspect.
+    compute_tooltip
+        Tooltip for the compute button.
+    """
+    name: str
+    label: str
+    detail_columns: tuple[tuple[str, int], ...] = ()
+    subject_width: int = 180
+    status_width: int = 110
+    missing_status: str | None = None
+    done_status: str | None = None
+    unit: str = 'subjects'
+    recording_unit: str | None = None
+    summary: str = ''
+    missing_note: str | None = None
+    shows_raw: bool = False
+    shows_epoch: bool = False
+    compute_label: str | None = None
+    compute_tooltip: str | None = None
+
+    def __repr__(self) -> str:
+        return f'<Task {self.name}>'
+
+    # ------------------------------------------------------------------
+    # Availability and toolbar
+
+    @staticmethod
+    def available(pipeline) -> bool:
+        """Whether this task applies to ``pipeline`` at all."""
+        return True
+
+    @staticmethod
+    def raw_choices(pipeline) -> list[str]:
+        """Raw pipes to offer in the Raw dropdown."""
+        return list(pipeline.get_field_values('raw'))
+
+    def computable(self, pipeline, epoch_rejection: str | None) -> bool:
+        """Whether the compute button applies to the current selection."""
+        return self.compute_label is not None
+
+    # ------------------------------------------------------------------
+    # Columns
+
+    def key_fields(self, pipeline, raw_name: str | None) -> tuple[str, ...]:
+        """State fields identifying a row; their column values form its ``combo``."""
+        return ('subject',)
+
+    def extra_columns(self, key_fields: tuple[str, ...]) -> tuple[tuple[str, int], ...]:
+        """``(title, width)`` for the columns between Subject and Status."""
+        return tuple((field.title(), 90) for field in key_fields[1:])
+
+    def layout(self, pipeline, raw_name: str | None) -> Layout:
+        """Resolve the column geometry; the single derivation of all three parts."""
+        key_fields = self.key_fields(pipeline, raw_name)
+        extra = self.extra_columns(key_fields)
+        columns = (('Subject', self.subject_width), *extra, ('Status', self.status_width), *self.detail_columns)
+        return Layout(key_fields, columns, 1 + len(extra))
+
+    # ------------------------------------------------------------------
+    # Row appearance
+
+    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+        """Text colour for a row, or ``None`` for the default."""
+        return None
+
+    def result_columns(self, result) -> tuple[str, ...]:
+        """Detail-column values describing a freshly computed artifact."""
+        raise NotImplementedError(f"{self.name} is not computable")
+
+    def missing_row(self, combo: tuple[str, ...], layout: Layout, status: str | None = None) -> tuple[str, ...]:
+        """Row for a key combination with no artifact: status plus placeholders.
+
+        Parameters
+        ----------
+        combo
+            Key-field column values the row is prefixed with.
+        layout
+            Column geometry the row has to fit. Any column between the key
+            fields and Status gets a placeholder too, so that the row is as
+            wide as the table even for a task whose leading columns are not all
+            key fields (MRI, Coregistration).
+        status
+            Status to show; defaults to :attr:`missing_status`.
+        """
+        n_lead = layout.status_col - len(combo)
+        n_detail = len(layout.columns) - layout.status_col - 1
+        return (*combo, *(PLACEHOLDER,) * n_lead, self.missing_status if status is None else status, *(PLACEHOLDER,) * n_detail)
+
+    # ------------------------------------------------------------------
+    # Status bar
+
+    def counts_row(self, row: tuple[str, ...]) -> bool:
+        """Whether a row counts towards the status-bar total."""
+        return True
+
+    def counts_done(self, status: str) -> bool:
+        return status == self.done_status
+
+    def counts_missing(self, status: str) -> bool:
+        return status == self.missing_status or (self.compute_label is not None and status in TRANSIENT_STATUS)
+
+    def status_bar(self, rows: list[tuple[str, ...]], layout: Layout) -> str:
+        """Summary of the whole table for the status bar."""
+        rows = [row for row in rows if self.counts_row(row)]
+        n_done = sum(1 for row in rows if self.counts_done(row[layout.status_col]))
+        # a task cached per recording shows one row per key-field combination, so
+        # counting them as subjects would overstate the total
+        unit = self.recording_unit if self.recording_unit and len(layout.key_fields) > 1 else self.unit
+        msg = f"{n_done} / {len(rows)} {unit} · {self.summary}"
+        if self.missing_note is not None:
+            n_missing = sum(1 for row in rows if self.counts_missing(row[layout.status_col]))
+            if n_missing:
+                noun = f" {self.missing_note}" if self.missing_note else ''
+                msg += f"  ({n_missing} missing{noun})"
+        return msg
+
+
+class BadChannelsTask(Task):
+    name = 'bad_chs'
+    label = "Bad channels"
+    detail_columns = (('N bad', 90),)
+    missing_status = 'error'  # loading seeds a missing channels.tsv, so the only failure is bad data
+    done_status = 'done'
+    summary = "bad channels defined"
+    recording_unit = 'recordings'
+    shows_raw = True
+
+    @staticmethod
+    def available(pipeline) -> bool:
+        return any(isinstance(pipe, RawSource) for pipe in pipeline._raw.values())
+
+    def key_fields(self, pipeline, raw_name: str | None) -> tuple[str, ...]:
+        # bad channels are stored per recording; show one row per combination of
+        # the key fields that vary in this experiment
+        fields = ['subject']
+        for field, values in (('session', pipeline._sessions), ('task', pipeline._tasks), ('run', pipeline._runs)):
+            if len(values) > 1:
+                fields.append(field)
+        return tuple(fields)
+
+    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+        return wx.RED if row[layout.status_col] == self.missing_status else None
+
+    def status_bar(self, rows: list[tuple[str, ...]], layout: Layout) -> str:
+        msg = super().status_bar(rows, layout)
+        n_error = sum(1 for row in rows if row[layout.status_col] == self.missing_status)
+        if n_error:
+            msg += f"  ({n_error} error)"
+        return msg
+
+
+class ICATask(Task):
+    name = 'ica'
+    label = "ICA"
+    detail_columns = (('Components', 110), ('Rejected', 90))
+    missing_status = 'no ICA'
+    done_status = 'selected'
+    summary = "ICA selected"
+    missing_note = 'ICA file'
+    recording_unit = 'recordings'
+    shows_raw = True
+    compute_label = "Make ICA"
+    compute_tooltip = "Compute ICA for all subjects with missing files"
+
+    @staticmethod
+    def available(pipeline) -> bool:
+        return any(isinstance(pipe, RawICA) for pipe in pipeline._raw.values())
+
+    @staticmethod
+    def raw_choices(pipeline) -> list[str]:
+        return [name for name, pipe in pipeline._raw.items() if isinstance(pipe, RawICA)]
+
+    def key_fields(self, pipeline, raw_name: str | None) -> tuple[str, ...]:
+        # ICA is cached per (subject, session[, run]); show one row per
+        # combination of the key fields that vary in this experiment.
+        fields = ['subject']
+        if len(pipeline._sessions) > 1:
+            fields.append('session')
+        if raw_name and not pipeline._raw[raw_name]._concatenate_runs and len(pipeline._runs) > 1:
+            fields.append('run')
+        return tuple(fields)
+
+    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+        # an ICA without a single rejected component is almost always an oversight
+        if row[layout.status_col] == self.done_status and row[layout.status_col + 2] == '0':
+            return wx.RED
+        return None
+
+    def result_columns(self, ica) -> tuple[str, ...]:
+        return str(ica.n_components_), str(len(ica.exclude))
+
+
+class EpochRejectionTask(Task):
+    name = 'epoch_rej'
+    label = "Epoch rejection"
+    detail_columns = (('N total', 90), ('N rejected', 90))
+    missing_status = 'missing'
+    done_status = 'done'
+    summary = "epoch rejection done"
+    shows_raw = True
+    shows_epoch = True
+    compute_label = "Compute rejection"
+    compute_tooltip = "Compute rejection files for all subjects with missing files"
+
+    @staticmethod
+    def available(pipeline) -> bool:
+        return any(rej is not None for rej in pipeline._epoch_rejection.values())
+
+    def computable(self, pipeline, epoch_rejection: str | None) -> bool:
+        # a ManualRejection is edited in its own GUI, not computed in bulk
+        return isinstance(pipeline._epoch_rejection.get(epoch_rejection), ChannelModelRejection)
+
+    def result_columns(self, ds) -> tuple[str, ...]:
+        return str(ds.n_cases), str(int((~ds['accept']).sum()))
+
+
+class MRITask(Task):
+    name = 'mri'
+    label = "MRI"
+    status_width = 130
+    missing_status = 'no MRI'
+    done_status = 'ok'
+    summary = "MRI available"
+    missing_note = ''
+
+    def extra_columns(self, key_fields: tuple[str, ...]) -> tuple[tuple[str, int], ...]:
+        # display-only, so it is not a key field: a row is still named by subject
+        return (('MRI subject', 170),)
+
+    def counts_row(self, row: tuple[str, ...]) -> bool:
+        return row[0] != COMMON_BRAIN_ROW
+
+    def counts_done(self, status: str) -> bool:
+        return status in (self.done_status, 'template')
+
+    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+        if row[layout.status_col] == self.missing_status:
+            return wx.RED
+        elif row[0] == COMMON_BRAIN_ROW:
+            return GREY
+        return None
+
+
+class CoregTask(Task):
+    name = 'coreg'
+    label = "Coregistration"
+    subject_width = 140
+    missing_status = 'missing'
+    done_status = 'ok'
+    unit = 'sessions'
+    summary = "coregistration done"
+    missing_note = ''
+
+    def key_fields(self, pipeline, raw_name: str | None) -> tuple[str, ...]:
+        return ('subject', 'session')
+
+    def extra_columns(self, key_fields: tuple[str, ...]) -> tuple[tuple[str, int], ...]:
+        # Session is a key field; MRI subject is display-only
+        return (('Session', 80), ('MRI subject', 140))
+
+    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+        return wx.RED if row[layout.status_col] == self.missing_status else None
+
+
+# Order determines the task dropdown
+TASKS = (BadChannelsTask(), ICATask(), EpochRejectionTask(), MRITask(), CoregTask())
+TASKS_BY_NAME = {task.name: task for task in TASKS}
+
+
 class PipelineFrame(EelbrainFrame):
     """Top-level window for inspecting and running pipeline setup tasks.
 
@@ -165,15 +518,20 @@ class PipelineFrame(EelbrainFrame):
         # usable after the inputs change: make_job() re-resolves dependencies live at
         # that point.
         self._job_specs: dict[tuple[tuple, tuple], JobSpec] = {}
-        self._tasks = []  # list of (task_type, task_key)
-        self._bad_chs_iter_fields: list[str] = []  # session/task/run columns for bad_chs
-        self._ica_iter_fields: list[str] = []  # session/run columns for ica
+        self._tasks: list[Task] = []  # dropdown entries, in order
+        # Column geometry of the displayed table, read by everything that addresses a
+        # row by column index. Installed by _setup_columns, first through the
+        # _on_task_changed() below and again whenever the task or Raw pipe changes.
+        # Part of a job's scope, so a row built for one layout is never written into
+        # another.
+        self._layout: Layout
 
         self._init_ui()
         self._populate_tasks()
-        if self._task_choice.GetCount():
-            self._task_choice.SetSelection(0)
-            self._on_task_changed(None)
+        # MRI and Coregistration are always offered, so the dropdown is never empty and
+        # a task is selected for the rest of the window's life
+        self._task_choice.SetSelection(0)
+        self._on_task_changed(None)
 
         # Width: fit the widest toolbar
         # Height: fill the usable display (wx.Fit() doesn't help here because the
@@ -227,17 +585,10 @@ class PipelineFrame(EelbrainFrame):
 
         toolbar.AddStretchSpacer()
 
-        # Make ICA button + progress (ICA tasks only)
-        self._make_ica_btn = wx.Button(self._panel, label="Make ICA", style=wx.BU_EXACTFIT)
-        self._make_ica_btn.SetToolTip("Compute ICA for all subjects with missing files")
-        self._make_ica_btn.Bind(wx.EVT_BUTTON, self._on_make_ica)
-        toolbar.Add(self._make_ica_btn, flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, border=6)
-
-        # Compute-rejection button (automatic epoch rejection only)
-        self._make_rej_btn = wx.Button(self._panel, label="Compute rejection", style=wx.BU_EXACTFIT)
-        self._make_rej_btn.SetToolTip("Compute rejection files for all subjects with missing files")
-        self._make_rej_btn.Bind(wx.EVT_BUTTON, self._on_make_rejection)
-        toolbar.Add(self._make_rej_btn, flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, border=6)
+        # Compute button + progress; label and visibility follow the task
+        self._compute_btn = wx.Button(self._panel, label="", style=wx.BU_EXACTFIT)
+        self._compute_btn.Bind(wx.EVT_BUTTON, self._on_compute)
+        toolbar.Add(self._compute_btn, flag=wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, border=6)
 
         self._progress_gauge = wx.Gauge(self._panel, style=wx.GA_HORIZONTAL | wx.GA_SMOOTH)
         self._progress_gauge.SetMinSize((100, -1))
@@ -269,8 +620,7 @@ class PipelineFrame(EelbrainFrame):
         for w in (self._epoch_rejection_label, self._epoch_rejection_choice,
                   self._epoch_label, self._epoch_choice,
                   self._raw_label, self._raw_choice,
-                  self._make_ica_btn, self._make_rej_btn,
-                  self._progress_gauge, self._progress_label):
+                  self._compute_btn, self._progress_gauge, self._progress_label):
             w.Hide()
 
     # ------------------------------------------------------------------
@@ -279,31 +629,24 @@ class PipelineFrame(EelbrainFrame):
     def _populate_tasks(self):
         # The task selects the operation; the raw pipe is chosen separately via
         # the Raw dropdown (filtered to the sources/ICA stages for the task).
-        if any(isinstance(pipe, RawSource) for pipe in self._pipeline._raw.values()):
-            self._tasks.append(('bad_chs', None))
-            self._task_choice.Append("Bad channels")
+        self._tasks = [task for task in TASKS if task.available(self._pipeline)]
+        for task in self._tasks:
+            self._task_choice.Append(task.label)
 
-        if any(isinstance(pipe, RawICA) for pipe in self._pipeline._raw.values()):
-            self._tasks.append(('ica', None))
-            self._task_choice.Append("ICA")
+    def _current_task(self) -> Task:
+        """Task selected in the dropdown; always set (see :meth:`__init__`)."""
+        return self._tasks[self._task_choice.GetSelection()]
 
-        if any(rej is not None for rej in self._pipeline._epoch_rejection.values()):
-            self._tasks.append(('epoch_rej', None))
-            self._task_choice.Append("Epoch rejection")
+    def _raw_name(self) -> str | None:
+        """Raw pipe the current table is for; ``None`` for a task without a Raw dropdown.
 
-        self._tasks.append(('mri', 'mri'))
-        self._task_choice.Append("MRI")
-        self._tasks.append(('coreg', 'coreg'))
-        self._task_choice.Append("Coregistration")
+        The dropdown keeps its selection while hidden, so the task decides whether
+        that selection means anything.
+        """
+        return self._raw_choice.GetStringSelection() if self._current_task().shows_raw else None
 
-    def _current_task(self) -> tuple[str | None, str | None]:
-        idx = self._task_choice.GetSelection()
-        if idx == wx.NOT_FOUND or idx >= len(self._tasks):
-            return None, None
-        return self._tasks[idx]
-
-    def _table_scope(self) -> tuple[str | None, str | None, str | None, str | None]:
-        """Identity of the table on display: ``(task_type, task_key, epoch, raw)``.
+    def _table_scope(self) -> tuple:
+        """Identity of the table on display: ``(task, epoch_rejection, epoch, raw, layout)``.
 
         Every choice that selects which rows are shown, and the arguments
         :meth:`_compute_rows` needs to produce them. A row ``combo`` only names a
@@ -311,15 +654,14 @@ class PipelineFrame(EelbrainFrame):
         row of another: the Raw, Epoch and Epoch-rejection choices stay enabled
         while a computation runs, and switching one of them (or the number of ICA
         key-field columns that follows from Raw) leaves the same combo pointing at
-        an unrelated recording.
+        an unrelated recording. The layout comes from :meth:`_setup_columns` rather
+        than being re-derived off the main thread, so a row can never come back the
+        wrong width.
         """
-        task_type, task_key = self._current_task()
-        epoch_name = self._epoch_choice.GetStringSelection() if task_type == 'epoch_rej' else None
-        raw_name = self._raw_choice.GetStringSelection() if task_type in ('epoch_rej', 'bad_chs', 'ica') else None
-        if task_type == 'epoch_rej':
-            # carry the selected rejection name through as task_key
-            task_key = self._current_epoch_rejection()
-        return task_type, task_key, epoch_name, raw_name
+        task = self._current_task()
+        epoch_rejection = self._current_epoch_rejection() if task.shows_epoch else None
+        epoch_name = self._epoch_choice.GetStringSelection() if task.shows_epoch else None
+        return task, epoch_rejection, epoch_name, self._raw_name(), self._layout
 
     def _populate_epoch_choices(self):
         previous = self._epoch_choice.GetStringSelection()
@@ -329,15 +671,11 @@ class PipelineFrame(EelbrainFrame):
                 self._epoch_choice.Append(name)
         self._restore_selection(self._epoch_choice, previous, 0)
 
-    def _populate_raw_choices(self, task_type: str):
-        """Fill the Raw dropdown with the pipes relevant to ``task_type``."""
+    def _populate_raw_choices(self, task: Task):
+        """Fill the Raw dropdown with the pipes relevant to ``task``."""
         previous = self._raw_choice.GetStringSelection()
         self._raw_choice.Clear()
-        if task_type == 'ica':
-            names = [name for name, pipe in self._pipeline._raw.items() if isinstance(pipe, RawICA)]
-        else:  # bad_chs / epoch_rej: any raw stage (source derived where needed)
-            names = list(self._pipeline.get_field_values('raw'))
-        for name in names:
+        for name in task.raw_choices(self._pipeline):
             self._raw_choice.Append(name)
         default = self._raw_choice.FindString('raw')
         self._restore_selection(self._raw_choice, previous, default if default != wx.NOT_FOUND else 0)
@@ -361,81 +699,48 @@ class PipelineFrame(EelbrainFrame):
     def _current_epoch_rejection(self) -> str | None:
         return self._epoch_rejection_choice.GetStringSelection() or None
 
-    def _update_rejection_button(self):
-        """Show the 'Compute rejection' button only for an automatic rejection."""
-        task_type, _ = self._current_task()
-        name = self._current_epoch_rejection()
-        is_auto = (task_type == 'epoch_rej' and name is not None
-                   and isinstance(self._pipeline._epoch_rejection[name], ChannelModelRejection))
-        self._make_rej_btn.Show(is_auto)
+    def _update_compute_button(self):
+        """Show the compute button, labelled for the task that can use it."""
+        task = self._current_task()
+        computable = task.computable(self._pipeline, self._current_epoch_rejection())
+        if computable:
+            self._compute_btn.SetLabel("Stop" if self._compute_token is not None else task.compute_label)
+            self._compute_btn.SetToolTip(task.compute_tooltip)
+        self._compute_btn.Show(computable)
         self._panel.Layout()
 
     def _on_epoch_rejection_changed(self, event):
-        self._update_rejection_button()
+        self._update_compute_button()
         self._start_refresh()
 
     # ------------------------------------------------------------------
     # Event handlers
 
     def _on_task_changed(self, event):
-        task_type, task_key = self._current_task()
+        task = self._current_task()
+        # Belt and braces: the task dropdown is disabled while a computation runs, so
+        # there is normally nothing to stop, and _setup_columns clears the rows anyway
         self._stop_compute()
-        if task_type == 'bad_chs':
-            p = self._pipeline
-            extra = []
-            if len(p._sessions) > 1:
-                extra.append('session')
-            if len(p._tasks) > 1:
-                extra.append('task')
-            if len(p._runs) > 1:
-                extra.append('run')
-            self._bad_chs_iter_fields = extra
-        show_epoch = task_type == 'epoch_rej'
-        show_raw = task_type in ('epoch_rej', 'bad_chs', 'ica')
-        self._epoch_rejection_label.Show(show_epoch)
-        self._epoch_rejection_choice.Show(show_epoch)
-        self._epoch_label.Show(show_epoch)
-        self._epoch_choice.Show(show_epoch)
-        self._raw_label.Show(show_raw)
-        self._raw_choice.Show(show_raw)
-        if show_epoch:
+        for widget in (self._epoch_rejection_label, self._epoch_rejection_choice, self._epoch_label, self._epoch_choice):
+            widget.Show(task.shows_epoch)
+        self._raw_label.Show(task.shows_raw)
+        self._raw_choice.Show(task.shows_raw)
+        if task.shows_epoch:
             self._populate_epoch_rejection_choices()
             self._populate_epoch_choices()
-        if show_raw:
-            self._populate_raw_choices(task_type)
-        if task_type == 'ica':
-            self._update_ica_iter_fields()
-        self._make_ica_btn.Show(task_type == 'ica')
-        self._update_rejection_button()
-        self._panel.Layout()
-        self._setup_columns(task_type)
+        if task.shows_raw:
+            self._populate_raw_choices(task)
+        self._update_compute_button()
+        self._setup_columns()
         self._start_refresh()
-
-    def _update_ica_iter_fields(self):
-        """Recompute the per-row key fields for the currently selected ICA raw.
-
-        ICA is cached per (subject, session[, run]); show one row per
-        combination of the key fields that vary in this experiment.
-        """
-        p = self._pipeline
-        raw_name = self._raw_choice.GetStringSelection()
-        extra = []
-        if len(p._sessions) > 1:
-            extra.append('session')
-        if raw_name and not p._raw[raw_name]._concatenate_runs and len(p._runs) > 1:
-            extra.append('run')
-        self._ica_iter_fields = extra
 
     def _on_state_changed(self, event):
         self._start_refresh()
 
     def _on_raw_changed(self, event):
-        # Switching the ICA raw pipe can change run concatenation, so recompute
-        # the per-row key fields and columns before refreshing.
-        task_type, _ = self._current_task()
-        if task_type == 'ica':
-            self._update_ica_iter_fields()
-            self._setup_columns(task_type)
+        # Switching the ICA raw pipe can change run concatenation, and with it the
+        # per-row key fields, so reinstall the columns before refreshing.
+        self._setup_columns()
         self._start_refresh()
 
     def _on_refresh(self, event):
@@ -447,8 +752,7 @@ class PipelineFrame(EelbrainFrame):
 
     def _on_item_right_click(self, event):
         """Row right-click: context menu (Bad channels task only)."""
-        task_type, _ = self._current_task()
-        if task_type != 'bad_chs':
+        if self._current_task().name != 'bad_chs':
             return
         idx = event.GetIndex()
         if idx == wx.NOT_FOUND:
@@ -466,10 +770,8 @@ class PipelineFrame(EelbrainFrame):
     def _set_bad_channels_dialog(self, idx: int) -> None:
         """Edit a row's bad channels via a text dialog with live validation."""
         pipeline = self._pipeline
-        raw_name = self._raw_choice.GetStringSelection()
-        state = {'subject': self._list.GetItemText(idx, 0)}
-        for col, field in enumerate(self._bad_chs_iter_fields, start=1):
-            state[field] = self._list.GetItemText(idx, col)
+        raw_name = self._raw_name()
+        state = dict(zip(self._layout.key_fields, self._row_combo(idx)))
         wx.BeginBusyCursor()
         try:
             pipeline.set(raw=raw_name, **state)
@@ -500,15 +802,13 @@ class PipelineFrame(EelbrainFrame):
     def _activate_row(self, idx: int) -> None:
         """Perform the double-click action for the row at ``idx``."""
         subject = self._list.GetItemText(idx, 0)
-        task_type, task_key = self._current_task()
-        if task_type is None:
-            return
+        task = self._current_task()
         # Loop so that after the user incorporates a stale ICA we can retry the
         # action through the same try, keeping the _USER_ERROR_TYPES handler
         # around the retry; every other path falls through to the return.
         while True:
             try:
-                self._activate_item(idx, subject, task_type, task_key)
+                self._activate_item(idx, subject, task)
             except ICAMissingError:
                 dlg = wx.MessageDialog(self, f"The ICA for {subject} has not been computed yet, so raw data at the ICA stage cannot be displayed. Compute the ICA first (Make ICA in the ICA task).", "ICA Not Computed", wx.OK | wx.ICON_INFORMATION)
                 dlg.ShowModal()
@@ -528,7 +828,7 @@ class PipelineFrame(EelbrainFrame):
                 # "Apply to all" is not offered here.
                 choice, _ = self._ask_stale_ica(subject, error)
                 if choice == StaleICADialog.INCORPORATE:
-                    self._pipeline.load_ica(raw=self._raw_choice.GetStringSelection(), accept_stale=True)
+                    self._pipeline.load_ica(raw=self._raw_name(), accept_stale=True)
                     continue  # manifest now matches; retry the action
                 elif choice == StaleICADialog.ABORT:
                     wx.CallAfter(wx.GetApp().ExitMainLoop)
@@ -538,15 +838,13 @@ class PipelineFrame(EelbrainFrame):
                     self._start_refresh()
             return
 
-    def _activate_item(self, idx, subject, task_type, task_key):
+    def _activate_item(self, idx: int, subject: str, task: Task):
         """Perform the action for a double-clicked row."""
         wx.BeginBusyCursor()
         try:
-            if task_type == 'bad_chs':
-                raw_name = self._raw_choice.GetStringSelection()
-                state = {'subject': subject}
-                for col, field in enumerate(self._bad_chs_iter_fields, start=1):
-                    state[field] = self._list.GetItemText(idx, col)
+            if task.name == 'bad_chs':
+                raw_name = self._raw_name()
+                state = dict(zip(self._layout.key_fields, self._row_combo(idx)))
                 frame = self._pipeline.make_bad_channels_selection(raw=raw_name, **state)
                 if frame is not None:
                     doc = frame.model.doc
@@ -554,20 +852,21 @@ class PipelineFrame(EelbrainFrame):
                         'saved',
                         lambda: wx.CallAfter(self._start_refresh),
                     )
-            elif task_type == 'ica':
-                raw_name = self._raw_choice.GetStringSelection()
+            elif task.name == 'ica':
+                raw_name = self._raw_name()
+                scope = self._table_scope()
                 combo = self._row_combo(idx)
-                state = dict(zip(('subject',) + tuple(self._ica_iter_fields), combo))
+                state = dict(zip(self._layout.key_fields, combo))
                 frame = self._pipeline.make_ica_selection(raw=raw_name, **state)
                 if frame is not None:
                     doc = frame.model.doc
                     # enables the ICA GUI to add bad channels it finds
-                    doc.bad_channels_callback = partial(self._on_ica_bad_channels, raw_name, state, self._table_scope(), combo, doc)
+                    doc.bad_channels_callback = partial(self._on_ica_bad_channels, raw_name, state, scope, combo, doc)
                     doc.callbacks.subscribe(
                         'saved',
-                        lambda: wx.CallAfter(self._update_ica_row, combo, doc),
+                        lambda: wx.CallAfter(self._update_ica_row, scope, combo, doc),
                     )
-            elif task_type == 'epoch_rej':
+            elif task.name == 'epoch_rej':
                 name = self._current_epoch_rejection()
                 if name is not None:
                     # opens an editable GUI for ManualRejection, read-only for an
@@ -576,14 +875,14 @@ class PipelineFrame(EelbrainFrame):
                         subject=subject,
                         epoch_rejection=name,
                         epoch=self._epoch_choice.GetStringSelection(),
-                        raw=self._raw_choice.GetStringSelection(),
+                        raw=self._raw_name(),
                     )
                     # Epoch rejection has no in-memory object to read from,
                     # so do a targeted single-subject refresh instead.
                     self._start_refresh()
-            elif task_type == 'mri':
+            elif task.name == 'mri':
                 self._on_mri_activated(idx, subject)
-            elif task_type == 'coreg':
+            elif task.name == 'coreg':
                 self._on_coreg_activated(idx)
         finally:
             wx.EndBusyCursor()
@@ -642,8 +941,8 @@ class PipelineFrame(EelbrainFrame):
         subjects_dir = str(self._pipeline.root / MRI_SDIR)
         common_brain = self._pipeline.get('common_brain')
 
-        if subject == '(common brain)':
-            if status == 'missing':
+        if subject == COMMON_BRAIN_ROW:
+            if status == COMMON_BRAIN_MISSING:
                 if mrisubject == 'fsaverage':
                     dlg = wx.MessageDialog(
                         self,
@@ -661,7 +960,7 @@ class PipelineFrame(EelbrainFrame):
                         "in the FreeSurfer subjects directory.",
                         "MRI not found", wx.OK | wx.ICON_INFORMATION, self,
                     )
-        elif status == 'no MRI':
+        elif status == MRITask.missing_status:
             dlg = wx.MessageDialog(
                 self,
                 f"To create a scaled template brain from {common_brain}, switch to the Coregistration task.",
@@ -699,34 +998,20 @@ class PipelineFrame(EelbrainFrame):
     # ------------------------------------------------------------------
     # Table management
 
-    def _setup_columns(self, task_type):
+    def _setup_columns(self) -> None:
+        """Install the columns for the current task and cache their geometry."""
+        self._layout = self._current_task().layout(self._pipeline, self._raw_name())
         self._list.ClearAll()
-        if task_type == 'bad_chs':
-            cols = [('Subject', 180)]
-            for f in self._bad_chs_iter_fields:
-                cols.append((f.title(), 90))
-            cols += [('Status', 110), ('N bad', 90)]
-        elif task_type == 'ica':
-            cols = [('Subject', 180)]
-            for f in self._ica_iter_fields:
-                cols.append((f.title(), 90))
-            cols += [('Status', 110), ('Components', 110), ('Rejected', 90)]
-        elif task_type == 'mri':
-            cols = [('Subject', 180), ('MRI subject', 170), ('Status', 130)]
-        elif task_type == 'coreg':
-            cols = [('Subject', 140), ('Session', 80), ('MRI subject', 140), ('Status', 110)]
-        else:
-            cols = [('Subject', 180), ('Status', 110), ('N total', 90), ('N rejected', 90)]
-        for i, (label, width) in enumerate(cols):
+        for i, (label, width) in enumerate(self._layout.columns):
             self._list.InsertColumn(i, label, width=width)
 
-    def _ica_status_col(self) -> int:
-        """Column index of the ICA Status column (after subject + key fields)."""
-        return 1 + len(self._ica_iter_fields)
+    def _row(self, idx: int) -> tuple[str, ...]:
+        """All column values of a row."""
+        return tuple(self._list.GetItemText(idx, c) for c in range(len(self._layout.columns)))
 
     def _row_combo(self, idx: int) -> tuple:
-        """Leading key-field column values of a row (everything before Status)."""
-        return tuple(self._list.GetItemText(idx, c) for c in range(self._status_col()))
+        """Key-field column values of a row, identifying it within the task."""
+        return tuple(self._list.GetItemText(idx, c) for c in range(len(self._layout.key_fields)))
 
     def _find_row(self, combo: tuple) -> int:
         """Row index whose leading columns match ``combo``, or -1."""
@@ -735,118 +1020,63 @@ class PipelineFrame(EelbrainFrame):
                 return i
         return -1
 
-    def _status_col(self) -> int:
-        """Column index of the Status column for the current task.
+    def _set_row_colour(self, idx: int, row: tuple[str, ...]) -> None:
+        """Apply the task's colour rule to a row, clearing it when none applies.
 
-        Also the number of leading key-field columns, i.e. the width of a row
-        ``combo`` (``(subject,)`` for tasks without extra key fields).
+        Rows without a rule are left with no explicit colour rather than being
+        painted the default one, so that the list can still invert them when they
+        are selected.
         """
-        task_type, _ = self._current_task()
-        return self._ica_status_col() if task_type == 'ica' else 1
+        colour = self._current_task().row_colour(row, self._layout)
+        self._list.SetItemTextColour(idx, wx.NullColour if colour is None else colour)
 
-    def _populate_table(self, rows: list[tuple[str, ...]], specs: dict[tuple, JobSpec], scope: tuple, token: object) -> None:
+    def _set_row_result(self, idx: int, status: str, values: tuple[str, ...]) -> None:
+        """Write the Status and detail columns of a row, and recolour it."""
+        self._list.SetItem(idx, self._layout.status_col, status)
+        for col, value in enumerate(values, self._layout.status_col + 1):
+            self._list.SetItem(idx, col, value)
+        self._set_row_colour(idx, self._row(idx))
+
+    def _populate_table(self, rows: list[tuple[str, ...]], specs: dict[tuple, JobSpec], token: object) -> None:
         if token is not self._refresh_token:
             return
         # Only writer of _job_specs, on the main thread and behind the token guard, so a
         # raw/task switch can never leave a spec from the previous table behind.
         self._job_specs = specs
-        task_type = scope[0]
         self._list.DeleteAllItems()
-        grey = wx.Colour(150, 150, 150)
         for row in rows:
             idx = self._list.InsertItem(self._list.GetItemCount(), row[0])
             for col, val in enumerate(row[1:], 1):
                 self._list.SetItem(idx, col, val)
-            if task_type == 'bad_chs':
-                status = row[-2]  # status is always second-to-last
-                if status == 'error':
-                    self._list.SetItemTextColour(idx, wx.RED)
-            elif task_type == 'ica':
-                # status is third-to-last, rejected count is last
-                if row[-3] == 'selected' and row[-1] == '0':
-                    self._list.SetItemTextColour(idx, wx.RED)
-            elif task_type == 'mri':
-                if row[2] == 'no MRI':
-                    self._list.SetItemTextColour(idx, wx.RED)
-                elif row[0] == '(common brain)':
-                    self._list.SetItemTextColour(idx, grey)
-            elif task_type == 'coreg':
-                if row[3] == 'missing':
-                    self._list.SetItemTextColour(idx, wx.RED)
+            self._set_row_colour(idx, row)
         self._refresh_status_bar()
 
-    def _update_ica_row(self, combo: tuple, doc) -> None:
+    def _update_ica_row(self, scope: tuple, combo: tuple, doc) -> None:
         """Update a single ICA row from the already-in-memory document (no disk I/O)."""
-        n_comp = doc.ica.n_components_
-        n_excl = len(doc.ica.exclude)
-        i = self._find_row(combo)
+        i = self._displayed_row(scope, combo)
         if i != -1:
-            status_col = self._ica_status_col()
-            self._list.SetItem(i, status_col, 'selected')
-            self._list.SetItem(i, status_col + 1, str(n_comp))
-            self._list.SetItem(i, status_col + 2, str(n_excl))
-            colour = wx.RED if n_excl == 0 else wx.SystemSettings.GetColour(wx.SYS_COLOUR_LISTBOXTEXT)
-            self._list.SetItemTextColour(i, colour)
+            task = scope[0]  # the scope matched, so this is the task on display
+            self._set_row_result(i, task.done_status, task.result_columns(doc.ica))
         self._refresh_status_bar()
 
     def _refresh_status_bar(self):
         """Recompute the status bar summary from the current table contents."""
-        task_type, _ = self._current_task()
-        n = self._list.GetItemCount()
-        if task_type == 'bad_chs':
-            n_done = sum(1 for i in range(n) if self._list.GetItemText(i, 1) == 'done')
-            n_error = sum(1 for i in range(n) if self._list.GetItemText(i, 1) == 'error')
-            msg = f"{n_done} / {n} subjects · bad channels defined"
-            if n_error:
-                msg += f"  ({n_error} error)"
-            self.SetStatusText(msg)
-            return
-        if task_type == 'ica':
-            status_col = self._ica_status_col()
-            n_ok = sum(1 for i in range(n) if self._list.GetItemText(i, status_col) == 'selected')
-            # queued and computing recordings have no ICA file either
-            n_missing = sum(1 for i in range(n) if self._list.GetItemText(i, status_col) in ('no ICA', 'queued', '⟳'))
-            unit = 'recordings' if self._ica_iter_fields else 'subjects'
-            msg = f"{n_ok} / {n} {unit} · ICA selected"
-            if n_missing:
-                msg += f"  ({n_missing} missing ICA file)"
-        elif task_type == 'epoch_rej':
-            n_ok = sum(1 for i in range(n) if self._list.GetItemText(i, 1) == 'done')
-            msg = f"{n_ok} / {n} subjects · epoch rejection done"
-        elif task_type == 'mri':
-            # exclude the common brain row from subject counts
-            subject_rows = [i for i in range(n) if self._list.GetItemText(i, 0) != '(common brain)']
-            n_sub = len(subject_rows)
-            n_ok = sum(1 for i in subject_rows if self._list.GetItemText(i, 2) in ('ok', 'template'))
-            n_missing = sum(1 for i in subject_rows if self._list.GetItemText(i, 2) == 'no MRI')
-            msg = f"{n_ok} / {n_sub} subjects · MRI available"
-            if n_missing:
-                msg += f"  ({n_missing} missing)"
-        elif task_type == 'coreg':
-            n_ok = sum(1 for i in range(n) if self._list.GetItemText(i, 3) == 'ok')
-            n_missing = sum(1 for i in range(n) if self._list.GetItemText(i, 3) == 'missing')
-            msg = f"{n_ok} / {n} sessions · coregistration done"
-            if n_missing:
-                msg += f"  ({n_missing} missing)"
-        else:
-            msg = ""
-        self.SetStatusText(msg)
+        rows = [self._row(i) for i in range(self._list.GetItemCount())]
+        self.SetStatusText(self._current_task().status_bar(rows, self._layout))
 
     # ------------------------------------------------------------------
     # Background status refresh
 
     def _start_refresh(self) -> None:
         scope = self._table_scope()
-        task_type, task_key, epoch_name, _ = scope
-        if task_type is None:
-            return
+        task, epoch_rejection, epoch_name, _, _ = scope
         token = object()
         self._refresh_token = token
         self._list.DeleteAllItems()
         self.SetStatusText("Loading…")
 
-        if task_type == 'epoch_rej':
-            if task_key is None:
+        if task.shows_epoch:
+            if epoch_rejection is None:
                 self.SetStatusText("No epoch rejection defined")
                 return
             if not epoch_name:
@@ -872,7 +1102,7 @@ class PipelineFrame(EelbrainFrame):
         except Exception as error:
             wx.CallAfter(self._show_error, *_error_dialog_args(error))
             return
-        wx.CallAfter(self._populate_table, rows, specs, scope, token)
+        wx.CallAfter(self._populate_table, rows, specs, token)
 
     def _show_error(self, tb: str, title: str = "Error", message: str | None = None):
         self.SetStatusText("Error")
@@ -901,38 +1131,14 @@ class PipelineFrame(EelbrainFrame):
     # ------------------------------------------------------------------
     # Background computation (one queue for every computable task)
 
-    # Per-task label for a row whose artifact has not been computed yet
-    _MISSING_STATUS = {'ica': 'no ICA', 'epoch_rej': 'missing'}
-    # Per-task label for a row whose artifact is available
-    _DONE_STATUS = {'ica': 'selected', 'epoch_rej': 'done'}
-
-    @staticmethod
-    def _result_columns(kind: str, result) -> tuple[str, ...]:
-        """Detail-column values (after Status) describing a computed artifact."""
-        if kind == 'ica':
-            return str(result.n_components_), str(len(result.exclude))
-        elif kind == 'epoch_rej':
-            return str(result.n_cases), str(int((~result['accept']).sum()))
-        raise RuntimeError(f"{kind=}")
-
-    def _on_make_ica(self, event):
+    def _on_compute(self, event):
+        """Compute button: queue every missing row of the current task, or stop."""
         if self._compute_token is not None:
             self._stop_compute()
             return
         scope = self._table_scope()
-        if scope[0] != 'ica':
-            return
-        self._queue_jobs(scope, self._missing_jobs(scope))
-
-    def _on_make_rejection(self, event):
-        if self._compute_token is not None:
-            self._stop_compute()
-            return
-        scope = self._table_scope()
-        name = self._current_epoch_rejection()
-        if scope[0] != 'epoch_rej' or name is None:
-            return
-        if not isinstance(self._pipeline._epoch_rejection[name], ChannelModelRejection):
+        task, epoch_rejection = scope[:2]
+        if not task.computable(self._pipeline, epoch_rejection):
             return
         self._queue_jobs(scope, self._missing_jobs(scope))
 
@@ -941,9 +1147,8 @@ class PipelineFrame(EelbrainFrame):
 
         Rows without a job spec (not computable) are skipped.
         """
-        status_col = self._status_col()
-        missing = self._MISSING_STATUS[scope[0]]
-        combos = [self._row_combo(i) for i in range(self._list.GetItemCount()) if self._list.GetItemText(i, status_col) == missing]
+        missing = scope[0].missing_status
+        combos = [self._row_combo(i) for i in range(self._list.GetItemCount()) if self._list.GetItemText(i, self._layout.status_col) == missing]
         return [(combo, self._job_specs[scope, combo]) for combo in combos if (scope, combo) in self._job_specs]
 
     def _queue_jobs(self, scope: tuple, jobs: list[tuple[tuple, JobSpec]]) -> None:
@@ -978,15 +1183,11 @@ class PipelineFrame(EelbrainFrame):
             self._job_queue.extend(new)
             self._n_total += len(new)
         # show the rows as waiting: their artifact is gone (or was never made)
-        if scope == self._table_scope():
-            status_col = self._status_col()
-            n_detail = self._list.GetColumnCount() - status_col - 1
-            for _, combo, _ in new:
-                i = self._find_row(combo)
-                if i != -1:
-                    self._list.SetItem(i, status_col, 'queued')
-                    for col in range(status_col + 1, status_col + 1 + n_detail):
-                        self._list.SetItem(i, col, '—')
+        n_detail = len(self._layout.columns) - self._layout.status_col - 1
+        for _, combo, _ in new:
+            i = self._displayed_row(scope, combo)
+            if i != -1:
+                self._set_row_result(i, 'queued', (PLACEHOLDER,) * n_detail)
         if self._compute_token is None:
             self._start_compute()
         else:
@@ -1017,8 +1218,7 @@ class PipelineFrame(EelbrainFrame):
         with self._job_queue_lock:
             self._n_total = len(self._job_queue)
 
-        self._make_ica_btn.SetLabel("Stop")
-        self._make_rej_btn.SetLabel("Stop")
+        self._update_compute_button()
         self._update_progress()
         self._progress_gauge.Show()
         self._progress_label.Show()
@@ -1031,8 +1231,7 @@ class PipelineFrame(EelbrainFrame):
 
     def _finish_compute_ui(self):
         """Restore toolbar controls after computation ends or is cancelled."""
-        self._make_ica_btn.SetLabel("Make ICA")
-        self._make_rej_btn.SetLabel("Compute rejection")
+        self._update_compute_button()
         self._progress_gauge.Hide()
         self._progress_label.Hide()
         self._refresh_btn.Enable()
@@ -1046,12 +1245,10 @@ class PipelineFrame(EelbrainFrame):
         self._compute_token = None
         with self._job_queue_lock:
             self._job_queue.clear()
-        task_type, _ = self._current_task()
-        missing = self._MISSING_STATUS.get(task_type, 'missing')
-        status_col = self._status_col()
+        missing = self._current_task().missing_status
         for i in range(self._list.GetItemCount()):
-            if self._list.GetItemText(i, status_col) in ('⟳', 'queued'):
-                self._list.SetItem(i, status_col, missing)
+            if self._list.GetItemText(i, self._layout.status_col) in TRANSIENT_STATUS:
+                self._list.SetItem(i, self._layout.status_col, missing)
         self._finish_compute_ui()
 
     def _compute_thread(self, token):
@@ -1072,13 +1269,13 @@ class PipelineFrame(EelbrainFrame):
                     break
                 scope, combo, spec = self._job_queue.pop(0)
                 self._job_in_progress = (scope, combo)
-            kind = scope[0]
+            task = scope[0]
             wx.CallAfter(self._on_job_computing, token, scope, combo)
             try:
-                result = self._compute_job(kind, spec, combo)
+                result = self._compute_job(task, spec, combo)
                 # Compute the columns before counting the job as done, so that a
                 # failure here goes through the error branch exactly once.
-                values = None if result is None else self._result_columns(kind, result)
+                values = None if result is None else task.result_columns(result)
                 self._n_done += 1
                 if values is None:  # user declined; the artifact is still missing
                     wx.CallAfter(self._on_job_skipped, token, scope, combo)
@@ -1097,7 +1294,7 @@ class PipelineFrame(EelbrainFrame):
                 with self._job_queue_lock:
                     self._job_in_progress = None
 
-    def _compute_job(self, kind: str, spec: JobSpec, combo: tuple):
+    def _compute_job(self, task: Task, spec: JobSpec, combo: tuple):
         """Compute and cache one job, or ``None`` when the user declined (worker thread).
 
         A stale ICA file may hold manual component selections, so it is never
@@ -1114,8 +1311,8 @@ class PipelineFrame(EelbrainFrame):
 
         Parameters
         ----------
-        kind
-            Task type the job belongs to.
+        task
+            Task the job belongs to.
         spec
             Host-side handle for the artifact.
         combo
@@ -1125,7 +1322,7 @@ class PipelineFrame(EelbrainFrame):
             with self._pipeline_lock:
                 job = spec.make_job()
         except ProtectedArtifactError as error:
-            if kind != 'ica':
+            if task.name != 'ica':
                 raise
             choice, _ = self._ask_stale_ica(combo[0], error)
             if choice == StaleICADialog.ABORT:
@@ -1160,7 +1357,7 @@ class PipelineFrame(EelbrainFrame):
             return
         i = self._displayed_row(scope, combo)
         if i != -1:
-            self._list.SetItem(i, self._status_col(), '⟳')
+            self._list.SetItem(i, self._layout.status_col, '⟳')
 
     def _on_job_skipped(self, token, scope, combo):
         """Restore a row after the user declined to compute it.
@@ -1174,7 +1371,7 @@ class PipelineFrame(EelbrainFrame):
             return
         i = self._displayed_row(scope, combo)
         if i != -1:
-            self._list.SetItem(i, self._status_col(), 'stale')
+            self._list.SetItem(i, self._layout.status_col, 'stale')
         self._update_progress()
         self._refresh_status_bar()
 
@@ -1184,14 +1381,7 @@ class PipelineFrame(EelbrainFrame):
             return
         i = self._displayed_row(scope, combo)
         if i != -1:
-            status_col = self._status_col()
-            self._list.SetItem(i, status_col, self._DONE_STATUS[scope[0]])
-            for col, value in enumerate(values, status_col + 1):
-                self._list.SetItem(i, col, value)
-            if scope[0] == 'ica':
-                colour = (wx.RED if values[-1] == '0'
-                          else wx.SystemSettings.GetColour(wx.SYS_COLOUR_LISTBOXTEXT))
-                self._list.SetItemTextColour(i, colour)
+            self._set_row_result(i, scope[0].done_status, values)
         self._update_progress()
         self._refresh_status_bar()
 
@@ -1201,7 +1391,7 @@ class PipelineFrame(EelbrainFrame):
             return
         i = self._displayed_row(scope, combo)
         if i != -1:
-            self._list.SetItem(i, self._status_col(), 'error')
+            self._list.SetItem(i, self._layout.status_col, 'error')
         self._update_progress()
         self._show_error(tb, f"{title}: {' '.join(combo)}", message)
 
@@ -1272,26 +1462,33 @@ class PipelineFrame(EelbrainFrame):
         dlg.Destroy()
         return delete
 
-    def _handle_stale_ica(self, combo: tuple, error: ProtectedArtifactError, choice: str | None, pipeline, raw_name: str) -> tuple:
+    def _handle_stale_ica(
+            self,
+            combo: tuple[str, ...],
+            scope: tuple,  # see :meth:`_table_scope`
+            error: ProtectedArtifactError,
+            choice: str | None,
+    ) -> tuple[str, ...]:
         """Apply a stale-ICA ``choice`` during refresh, returning a table row tuple.
 
         ``combo`` holds the leading key-field columns (subject and any
         session/run columns) that the row is prefixed with.
         """
+        task, _, _, raw_name, layout = scope
         if choice == StaleICADialog.ABORT:
             wx.CallAfter(wx.GetApp().ExitMainLoop)
             raise _AbortRequested()
         elif choice == StaleICADialog.DELETE:
             Path(error.path).unlink()
-            return combo + ('no ICA', '—', '—')
+            return task.missing_row(combo, layout)
         elif choice == StaleICADialog.INCORPORATE:
-            ica = pipeline.load_ica(raw=raw_name, accept_stale=True)
-            return combo + ('selected', str(ica.n_components_), str(len(ica.exclude)))
+            ica = self._pipeline.load_ica(raw=raw_name, accept_stale=True)
+            return (*combo, task.done_status, *task.result_columns(ica))
         elif choice == StaleICADialog.IGNORE:
             ica = mne.preprocessing.read_ica(error.path)
-            return combo + ('stale', str(ica.n_components_), str(len(ica.exclude)))
+            return (*combo, 'stale', *task.result_columns(ica))
         else:  # dialog dismissed without a choice
-            return combo + ('stale', '—', '—')
+            return task.missing_row(combo, layout, 'stale')
 
     def _fetch_fsaverage(self):
         """Download fsaverage to the experiment's FreeSurfer subjects directory in a thread."""
@@ -1337,17 +1534,14 @@ class PipelineFrame(EelbrainFrame):
             token: object,
             scope: tuple,  # see :meth:`_table_scope`
     ) -> tuple[list[tuple[str, ...]], dict[tuple[tuple, tuple], JobSpec]]:
-        task_type, task_key, epoch_name, raw_name = scope
+        task, epoch_rejection, epoch_name, raw_name, layout = scope
         pipeline = self._pipeline
         rows = []
         specs: dict[tuple[tuple, tuple], JobSpec] = {}
 
-        if task_type == 'bad_chs':
+        if task.name == 'bad_chs':
             source_name = pipeline._raw.root_source_name(raw_name)
-            extra = self._bad_chs_iter_fields
-            iter_fields = ('subject',) + tuple(extra)
-            iter_arg = iter_fields[0] if len(iter_fields) == 1 else list(iter_fields)
-            for combo in pipeline.iter(iter_arg):
+            for combo in pipeline.iter(layout.iter_arg):
                 if token is not self._refresh_token:
                     break
                 if isinstance(combo, str):
@@ -1359,16 +1553,13 @@ class PipelineFrame(EelbrainFrame):
                 try:
                     bads = bads_ctx.load()  # seeds a missing derivatives channels.tsv
                 except DataError:  # EEG channels without positions
-                    rows.append(combo + ('error', '—'))
+                    rows.append(task.missing_row(combo, layout))
                 else:
-                    rows.append(combo + ('done', str(len(bads))))
+                    rows.append((*combo, task.done_status, str(len(bads))))
 
-        elif task_type == 'ica':
+        elif task.name == 'ica':
             bulk_choice = None  # set once the user ticks "Apply to all"
-            extra = self._ica_iter_fields
-            iter_fields = ('subject',) + tuple(extra)
-            iter_arg = iter_fields[0] if len(iter_fields) == 1 else list(iter_fields)
-            for combo in pipeline.iter(iter_arg):
+            for combo in pipeline.iter(layout.iter_arg):
                 if token is not self._refresh_token:
                     break
                 if isinstance(combo, str):
@@ -1380,7 +1571,7 @@ class PipelineFrame(EelbrainFrame):
                 if status == 'ok':
                     try:
                         ica = ctx.load()
-                        rows.append(combo + ('selected', str(ica.n_components_), str(len(ica.exclude))))
+                        rows.append((*combo, task.done_status, *task.result_columns(ica)))
                     except ProtectedArtifactError as error:
                         if bulk_choice is None:
                             choice, apply_to_all = self._ask_stale_ica(subject, error, allow_apply_to_all=True)
@@ -1388,18 +1579,17 @@ class PipelineFrame(EelbrainFrame):
                                 bulk_choice = choice
                         else:
                             choice = bulk_choice
-                        row = self._handle_stale_ica(combo, error, choice, pipeline, raw_name)
-                        rows.append(row)
+                        rows.append(self._handle_stale_ica(combo, scope, error, choice))
                 elif status == 'missing-ica':
-                    rows.append(combo + ('no ICA', '—', '—'))
+                    rows.append(task.missing_row(combo, layout))
                 else:
-                    rows.append(combo + ('no data', '—', '—'))
+                    rows.append(task.missing_row(combo, layout, 'no data'))
 
-        elif task_type == 'epoch_rej':
-            rej = pipeline._epoch_rejection[task_key]
+        elif task.name == 'epoch_rej':
+            rej = pipeline._epoch_rejection[epoch_rejection]
             node_name = 'epoch-rejection-input' if isinstance(rej, ManualRejection) else 'epoch-rejection-channel-model'
             for subject in pipeline.iter(
-                    raw=raw_name, epoch=epoch_name, epoch_rejection=task_key):
+                    layout.iter_arg, raw=raw_name, epoch=epoch_name, epoch_rejection=epoch_rejection):
                 if token is not self._refresh_token:
                     break
                 rej_ctx = pipeline._resolve_derivative(node_name)
@@ -1412,33 +1602,31 @@ class PipelineFrame(EelbrainFrame):
                     path = spec.path
                 if path.exists():
                     ds = load.unpickle(path)
-                    n_rej = int((~ds['accept']).sum())
-                    rows.append((subject, 'done',
-                                 str(ds.n_cases), str(n_rej)))
+                    rows.append((subject, task.done_status, *task.result_columns(ds)))
                 else:
-                    rows.append((subject, 'missing', '—', '—'))
+                    rows.append(task.missing_row((subject,), layout))
 
-        elif task_type == 'mri':
+        elif task.name == 'mri':
             subjects_dir = pipeline.root / MRI_SDIR
-            for subject in pipeline:
+            for subject in pipeline.iter(layout.iter_arg):
                 if token is not self._refresh_token:
                     break
                 mrisubject = pipeline.get('mrisubject')
                 has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
                 if has_recon:
-                    status = 'template' if is_fake_mri(subjects_dir / mrisubject) else 'ok'
+                    status = 'template' if is_fake_mri(subjects_dir / mrisubject) else task.done_status
                 else:
-                    status = 'no MRI'
+                    status = task.missing_status
                 rows.append((subject, mrisubject, status))
             # Common brain row at the bottom
             common_brain = pipeline.get('common_brain')
             if common_brain:
                 has_cb = (subjects_dir / common_brain / 'surf' / 'lh.pial').exists()
-                rows.append(('(common brain)', common_brain, 'ok' if has_cb else 'missing'))
+                rows.append((COMMON_BRAIN_ROW, common_brain, task.done_status if has_cb else COMMON_BRAIN_MISSING))
 
-        elif task_type == 'coreg':
+        elif task.name == 'coreg':
             raw_input = raw_input_name('raw')
-            for subject, session in pipeline.iter(('subject', 'session'), raw='raw'):
+            for subject, session in pipeline.iter(layout.iter_arg, raw='raw'):
                 if token is not self._refresh_token:
                     break
                 raw_ctx = pipeline._resolve_derivative(raw_input)
@@ -1447,6 +1635,6 @@ class PipelineFrame(EelbrainFrame):
                 mrisubject = pipeline.get('mrisubject')
                 trans_ctx = pipeline._resolve_derivative('trans-input')
                 has_trans = trans_ctx.node.exists(trans_ctx)
-                rows.append((subject, session, mrisubject, 'ok' if has_trans else 'missing'))
+                rows.append((subject, session, mrisubject, task.done_status if has_trans else task.missing_status))
 
         return rows, specs

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -1,4 +1,6 @@
 """Pipeline supervisor GUI launched by ``eelbrain-gui``."""
+from __future__ import annotations
+
 import logging
 import subprocess
 import sys
@@ -9,11 +11,13 @@ from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import mne
 import wx
 
 from .. import load
+from .._data_obj import Dataset
 from .._exceptions import ConfigurationError, DataError
 from .._experiment.derivative_cache import ALLOW_PROTECTED_OVERWRITE, JobSpec, ProtectedArtifactError
 from .._experiment.epoch_rejection import ChannelModelRejection, ManualRejection
@@ -25,6 +29,9 @@ from .._utils.mne_utils import is_fake_mri
 from .frame import EelbrainFrame
 from .select_components import Document as ICADocument
 from .utils import StaleICADialog, TracebackDialog
+
+if TYPE_CHECKING:
+    from .._experiment.pipeline import Pipeline
 
 
 def _launch_coreg_subprocess(
@@ -265,23 +272,31 @@ class Task:
     # Availability and toolbar
 
     @staticmethod
-    def available(pipeline) -> bool:
+    def available(pipeline: Pipeline) -> bool:
         """Whether this task applies to ``pipeline`` at all."""
         return True
 
     @staticmethod
-    def raw_choices(pipeline) -> list[str]:
+    def raw_choices(pipeline: Pipeline) -> list[str]:
         """Raw pipes to offer in the Raw dropdown."""
         return list(pipeline.get_field_values('raw'))
 
-    def computable(self, pipeline, epoch_rejection: str | None) -> bool:
+    def computable(
+            self,
+            pipeline: Pipeline,
+            epoch_rejection: str | None,
+    ) -> bool:
         """Whether the compute button applies to the current selection."""
         return self.compute_label is not None
 
     # ------------------------------------------------------------------
     # Columns
 
-    def key_fields(self, pipeline, raw_name: str | None) -> tuple[str, ...]:
+    def key_fields(
+            self,
+            pipeline: Pipeline,
+            raw_name: str | None,
+    ) -> tuple[str, ...]:
         """State fields identifying a row; their column values form its ``combo``."""
         return ('subject',)
 
@@ -289,7 +304,11 @@ class Task:
         """``(title, width)`` for the columns between Subject and Status."""
         return tuple((field.title(), 90) for field in key_fields[1:])
 
-    def layout(self, pipeline, raw_name: str | None) -> Layout:
+    def layout(
+            self,
+            pipeline: Pipeline,
+            raw_name: str | None,
+    ) -> Layout:
         """Resolve the column geometry; the single derivation of all three parts."""
         key_fields = self.key_fields(pipeline, raw_name)
         extra = self.extra_columns(key_fields)
@@ -307,7 +326,7 @@ class Task:
         """Text colour for a row, or ``None`` for the default."""
         return None
 
-    def result_columns(self, result) -> tuple[str, ...]:
+    def result_columns(self, result: object) -> tuple[str, ...]:
         """Detail-column values describing a freshly computed artifact."""
         raise NotImplementedError(f"{self.name} is not computable")
 
@@ -384,10 +403,14 @@ class BadChannelsTask(Task):
     shows_raw = True
 
     @staticmethod
-    def available(pipeline) -> bool:
+    def available(pipeline: Pipeline) -> bool:
         return any(isinstance(pipe, RawSource) for pipe in pipeline._raw.values())
 
-    def key_fields(self, pipeline, raw_name: str | None) -> tuple[str, ...]:
+    def key_fields(
+            self,
+            pipeline: Pipeline,
+            raw_name: str | None,
+    ) -> tuple[str, ...]:
         # bad channels are stored per recording; show one row per combination of
         # the key fields that vary in this experiment
         fields = ['subject']
@@ -411,14 +434,18 @@ class ICATask(Task):
     compute_tooltip = "Compute ICA for all subjects with missing files"
 
     @staticmethod
-    def available(pipeline) -> bool:
+    def available(pipeline: Pipeline) -> bool:
         return any(isinstance(pipe, RawICA) for pipe in pipeline._raw.values())
 
     @staticmethod
-    def raw_choices(pipeline) -> list[str]:
+    def raw_choices(pipeline: Pipeline) -> list[str]:
         return [name for name, pipe in pipeline._raw.items() if isinstance(pipe, RawICA)]
 
-    def key_fields(self, pipeline, raw_name: str | None) -> tuple[str, ...]:
+    def key_fields(
+            self,
+            pipeline: Pipeline,
+            raw_name: str | None,
+    ) -> tuple[str, ...]:
         # ICA is cached per (subject, session[, run]); show one row per
         # combination of the key fields that vary in this experiment.
         fields = ['subject']
@@ -438,7 +465,7 @@ class ICATask(Task):
             return wx.RED
         return None
 
-    def result_columns(self, ica) -> tuple[str, ...]:
+    def result_columns(self, ica: mne.preprocessing.ICA) -> tuple[str, ...]:
         return str(ica.n_components_), str(len(ica.exclude))
 
 
@@ -455,14 +482,18 @@ class EpochRejectionTask(Task):
     compute_tooltip = "Compute rejection files for all subjects with missing files"
 
     @staticmethod
-    def available(pipeline) -> bool:
+    def available(pipeline: Pipeline) -> bool:
         return any(rej is not None for rej in pipeline._epoch_rejection.values())
 
-    def computable(self, pipeline, epoch_rejection: str | None) -> bool:
+    def computable(
+            self,
+            pipeline: Pipeline,
+            epoch_rejection: str | None,
+    ) -> bool:
         # a ManualRejection is edited in its own GUI, not computed in bulk
         return isinstance(pipeline._epoch_rejection.get(epoch_rejection), ChannelModelRejection)
 
-    def result_columns(self, ds) -> tuple[str, ...]:
+    def result_columns(self, ds: Dataset) -> tuple[str, ...]:
         return str(ds.n_cases), str(int((~ds['accept']).sum()))
 
 
@@ -507,7 +538,11 @@ class CoregTask(Task):
     summary = "coregistration done"
     missing_note = ''
 
-    def key_fields(self, pipeline, raw_name: str | None) -> tuple[str, ...]:
+    def key_fields(
+            self,
+            pipeline: Pipeline,
+            raw_name: str | None,
+    ) -> tuple[str, ...]:
         return ('subject', 'session')
 
     def extra_columns(self, key_fields: tuple[str, ...]) -> tuple[tuple[str, int], ...]:
@@ -724,7 +759,7 @@ class PipelineFrame(EelbrainFrame):
                 self._epoch_choice.Append(name)
         self._restore_selection(self._epoch_choice, previous, 0)
 
-    def _populate_raw_choices(self, task: Task):
+    def _populate_raw_choices(self, task: Task) -> None:
         """Fill the Raw dropdown with the pipes relevant to ``task``."""
         previous = self._raw_choice.GetStringSelection()
         self._raw_choice.Clear()
@@ -895,7 +930,7 @@ class PipelineFrame(EelbrainFrame):
                     self._start_refresh()
             return
 
-    def _activate_item(self, idx: int, subject: str, task: Task):
+    def _activate_item(self, idx: int, subject: str, task: Task) -> None:
         """Perform the action for a double-clicked row."""
         wx.BeginBusyCursor()
         try:

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -298,7 +298,11 @@ class Task:
     # ------------------------------------------------------------------
     # Row appearance
 
-    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+    def row_colour(
+            self,
+            row: tuple[str, ...],
+            layout: Layout,
+    ) -> wx.Colour | None:
         """Text colour for a row, or ``None`` for the default."""
         return None
 
@@ -306,7 +310,12 @@ class Task:
         """Detail-column values describing a freshly computed artifact."""
         raise NotImplementedError(f"{self.name} is not computable")
 
-    def missing_row(self, combo: tuple[str, ...], layout: Layout, status: str | None = None) -> tuple[str, ...]:
+    def missing_row(
+            self,
+            combo: tuple[str, ...],
+            layout: Layout,
+            status: str | None = None,
+    ) -> tuple[str, ...]:
         """Row for a key combination with no artifact to show: status plus placeholders.
 
         Also the row of the first refresh pass, whose status is not known yet
@@ -341,7 +350,11 @@ class Task:
     def counts_missing(self, status: str) -> bool:
         return status == self.missing_status or (self.compute_label is not None and status in TRANSIENT_STATUS)
 
-    def status_bar(self, rows: list[tuple[str, ...]], layout: Layout) -> str:
+    def status_bar(
+            self,
+            rows: list[tuple[str, ...]],
+            layout: Layout,
+    ) -> str:
         """Summary of the whole table for the status bar."""
         rows = [row for row in rows if self.counts_row(row)]
         n_done = sum(1 for row in rows if self.counts_done(row[layout.status_col]))
@@ -380,10 +393,18 @@ class BadChannelsTask(Task):
                 fields.append(field)
         return tuple(fields)
 
-    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+    def row_colour(
+            self,
+            row: tuple[str, ...],
+            layout: Layout,
+    ) -> wx.Colour | None:
         return wx.RED if row[layout.status_col] == self.missing_status else None
 
-    def status_bar(self, rows: list[tuple[str, ...]], layout: Layout) -> str:
+    def status_bar(
+            self,
+            rows: list[tuple[str, ...]],
+            layout: Layout,
+    ) -> str:
         msg = super().status_bar(rows, layout)
         n_error = sum(1 for row in rows if row[layout.status_col] == self.missing_status)
         if n_error:
@@ -422,7 +443,11 @@ class ICATask(Task):
             fields.append('run')
         return tuple(fields)
 
-    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+    def row_colour(
+            self,
+            row: tuple[str, ...],
+            layout: Layout,
+    ) -> wx.Colour | None:
         # an ICA without a single rejected component is almost always an oversight
         if row[layout.status_col] == self.done_status and row[layout.status_col + 2] == '0':
             return wx.RED
@@ -475,7 +500,11 @@ class MRITask(Task):
     def counts_done(self, status: str) -> bool:
         return status in (self.done_status, 'template')
 
-    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+    def row_colour(
+            self,
+            row: tuple[str, ...],
+            layout: Layout,
+    ) -> wx.Colour | None:
         if row[layout.status_col] == self.missing_status:
             return wx.RED
         elif row[0] == COMMON_BRAIN_ROW:
@@ -500,7 +529,11 @@ class CoregTask(Task):
         # Session is a key field; MRI subject is display-only
         return (('Session', 80), ('MRI subject', 140))
 
-    def row_colour(self, row: tuple[str, ...], layout: Layout) -> wx.Colour | None:
+    def row_colour(
+            self,
+            row: tuple[str, ...],
+            layout: Layout,
+    ) -> wx.Colour | None:
         return wx.RED if row[layout.status_col] == self.missing_status else None
 
 
@@ -1067,7 +1100,12 @@ class PipelineFrame(EelbrainFrame):
         colour = wx.RED if row[self._layout.status_col] == ERROR else self._current_task().row_colour(row, self._layout)
         self._list.SetItemTextColour(idx, wx.NullColour if colour is None else colour)
 
-    def _set_row_result(self, idx: int, status: str, values: tuple[str, ...]) -> None:
+    def _set_row_result(
+            self,
+            idx: int,
+            status: str,
+            values: tuple[str, ...],
+    ) -> None:
         """Write the Status and detail columns of a row, and recolour it."""
         self._list.SetItem(idx, self._layout.status_col, status)
         for col, value in enumerate(values, self._layout.status_col + 1):
@@ -1106,6 +1144,22 @@ class PipelineFrame(EelbrainFrame):
         refresh resolves the rows the first pass found, in order, and ``token``
         guarantees the table on display is still the one they were found for. The combo
         is verified all the same, so a row can never be given another recording's status.
+
+        Parameters
+        ----------
+        token
+            Refresh the row belongs to; a row of a superseded refresh is dropped.
+        scope
+            Table the row belongs to (see :meth:`_table_scope`); with ``combo``, the
+            key of its job spec.
+        index
+            Position of the row in the table.
+        combo
+            Key-field column values identifying the row.
+        row
+            All column values of the row.
+        spec
+            Job spec for the row's artifact; ``None`` if it can not be computed.
         """
         if token is not self._refresh_token:
             return
@@ -1119,7 +1173,12 @@ class PipelineFrame(EelbrainFrame):
         self._n_loading -= 1
         self._refresh_status_bar()
 
-    def _update_ica_row(self, scope: tuple, combo: tuple, doc) -> None:
+    def _update_ica_row(
+            self,
+            scope: tuple,  # see :meth:`_table_scope`
+            combo: tuple,
+            doc: ICADocument,
+    ) -> None:
         """Update a single ICA row from the already-in-memory document (no disk I/O)."""
         i = self._displayed_row(scope, combo)
         if i != -1:
@@ -1401,7 +1460,12 @@ class PipelineFrame(EelbrainFrame):
                 with self._job_queue_lock:
                     self._job_in_progress = None
 
-    def _compute_job(self, task: Task, spec: JobSpec, combo: tuple):
+    def _compute_job(
+            self,
+            task: Task,
+            spec: JobSpec,
+            combo: tuple,
+    ):
         """Compute and cache one job, or ``None`` when the user declined (worker thread).
 
         A stale ICA file may hold manual component selections, so it is never

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -1269,10 +1269,27 @@ class PipelineFrame(EelbrainFrame):
             return  # app exit already scheduled
         except Exception as error:
             wx.CallAfter(self._show_error, *_error_dialog_args(error))
+            wx.CallAfter(self._end_refresh, token)
             return
         log.debug(f"Pipeline GUI {task.name}: {n_filled} row details in {time.time() - t_locked:.3f} s, after waiting {t_locked - t_start:.3f} s for the pipeline")
         if first_error is not None:
             wx.CallAfter(self._show_error, *_error_dialog_args(first_error))
+
+    def _end_refresh(self, token: object) -> None:
+        """Settle the table of a refresh whose second pass failed: rows it never filled in are shown as errors.
+
+        Parameters
+        ----------
+        token
+            Refresh that ended; one that was superseded has nothing to settle.
+        """
+        if token is not self._refresh_token or not self._n_loading:
+            return
+        for i in range(self._list.GetItemCount()):
+            if self._list.GetItemText(i, self._layout.status_col) == LOADING:
+                self._set_row_result(i, ERROR, ())
+        self._n_loading = 0
+        self._refresh_status_bar()
 
     def _show_error(self, tb: str, title: str = "Error", message: str | None = None):
         self.SetStatusText("Error")

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -1870,18 +1870,15 @@ class PipelineFrame(EelbrainFrame):
                             row = task.missing_row(combo, layout)
 
                     elif task.name == 'mri':
-                        subjects_dir = pipeline.root / MRI_SDIR
-                        if combo == (COMMON_BRAIN_ROW,):
-                            mrisubject = pipeline.get('common_brain')
-                            has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
-                            status = task.done_status if has_recon else COMMON_BRAIN_MISSING
+                        is_common_brain = combo == (COMMON_BRAIN_ROW,)
+                        mrisubject = pipeline.get('common_brain' if is_common_brain else 'mrisubject')
+                        mri_dir = pipeline.root / MRI_SDIR / mrisubject
+                        if not (mri_dir / 'surf' / 'lh.pial').exists():
+                            status = COMMON_BRAIN_MISSING if is_common_brain else task.missing_status
+                        elif not is_common_brain and is_fake_mri(mri_dir):
+                            status = 'template'
                         else:
-                            mrisubject = pipeline.get('mrisubject')
-                            has_recon = (subjects_dir / mrisubject / 'surf' / 'lh.pial').exists()
-                            if has_recon:
-                                status = 'template' if is_fake_mri(subjects_dir / mrisubject) else task.done_status
-                            else:
-                                status = task.missing_status
+                            status = task.done_status
                         row = (*combo, mrisubject, status)
 
                     elif task.name == 'coreg':

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -836,6 +836,8 @@ class PipelineFrame(EelbrainFrame):
 
     def _activate_row(self, idx: int) -> None:
         """Perform the double-click action for the row at ``idx``."""
+        if self._list.GetItemText(idx, self._layout.status_col) == LOADING:
+            return  # the row's columns are still placeholders (see _refresh_thread)
         subject = self._list.GetItemText(idx, 0)
         task = self._current_task()
         # Loop so that after the user incorporates a stale ICA we can retry the

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -853,7 +853,7 @@ class PipelineFrame(EelbrainFrame):
             except _USER_ERROR_TYPES as error:
                 self._show_error(*_error_dialog_args(error))
             except ICAChannelsChangedError as error:
-                if self._ask_ica_channels_changed():
+                if self._ask_ica_channels_changed(error):
                     Path(error.path).unlink()
                     self._start_refresh()
                 else:
@@ -1546,8 +1546,13 @@ class PipelineFrame(EelbrainFrame):
         ready.wait()
         return result[0]
 
-    def _ask_ica_channels_changed(self) -> bool:
+    def _ask_ica_channels_changed(self, error: ICAChannelsChangedError) -> bool:
         """Prompt when bad channels changed since the ICA was created.
+
+        Parameters
+        ----------
+        error
+            The error, listing the bad channels then and now.
 
         Returns ``True`` to delete the ICA, ``False`` to abort.
         """
@@ -1557,6 +1562,7 @@ class PipelineFrame(EelbrainFrame):
             "Bad channels changed",
             wx.YES_NO | wx.ICON_WARNING,
         )
+        dlg.SetExtendedMessage(f"When the ICA was created: {', '.join(error.bads_before) or 'none'}\nNow: {', '.join(error.bads_after) or 'none'}")
         dlg.SetYesNoLabels("Delete ICA", "Abort")
         delete = dlg.ShowModal() == wx.ID_YES
         dlg.Destroy()

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -543,6 +543,7 @@ class PipelineFrame(EelbrainFrame):
         self._job_in_progress = None  # (scope, combo) the worker popped and is computing
         self._job_queue_lock = threading.Lock()
         self._n_done = self._n_total = 0  # progress of the current run
+        self._n_loading = 0  # rows of the displayed table whose status is still to be filled in
         # Job specs for the rows currently displayed, keyed by (scope, combo). Minted
         # during refresh (where pipeline.iter() sets the state), cleared for the new table
         # by _populate_table and filled in row by row by _fill_row. The scope is part of
@@ -1080,6 +1081,7 @@ class PipelineFrame(EelbrainFrame):
         # switch can never leave a spec from the previous table behind.
         self._job_specs = {}
         self._list.DeleteAllItems()
+        self._n_loading = len(rows)
         for row in rows:
             idx = self._list.InsertItem(self._list.GetItemCount(), row[0])
             for col, val in enumerate(row[1:], 1):
@@ -1112,6 +1114,7 @@ class PipelineFrame(EelbrainFrame):
         for col, value in enumerate(row):
             self._list.SetItem(index, col, value)
         self._set_row_colour(index, row)
+        self._n_loading -= 1
         self._refresh_status_bar()
 
     def _update_ica_row(self, scope: tuple, combo: tuple, doc) -> None:
@@ -1126,13 +1129,14 @@ class PipelineFrame(EelbrainFrame):
         """Recompute the status bar summary from the current table contents.
 
         While the second pass of a refresh is still filling rows in, the summary would
-        undercount, so the progress of that pass is shown instead.
+        undercount, so the progress of that pass is shown instead; that is called once
+        per row, so it is counted rather than read off the table.
         """
-        rows = [self._row(i) for i in range(self._list.GetItemCount())]
-        n_loading = sum(1 for row in rows if row[self._layout.status_col] == LOADING)
-        if n_loading:
-            self.SetStatusText(f"Loading… {len(rows) - n_loading} / {len(rows)}")
+        n = self._list.GetItemCount()
+        if self._n_loading:
+            self.SetStatusText(f"Loading… {n - self._n_loading} / {n}")
         else:
+            rows = [self._row(i) for i in range(n)]
             self.SetStatusText(self._current_task().status_bar(rows, self._layout))
 
     # ------------------------------------------------------------------
@@ -1144,6 +1148,7 @@ class PipelineFrame(EelbrainFrame):
         token = object()
         self._refresh_token = token
         self._list.DeleteAllItems()
+        self._n_loading = 0
         self.SetStatusText("Loading…")
 
         if task.shows_epoch:

--- a/eelbrain/_wxgui/pipeline_gui.py
+++ b/eelbrain/_wxgui/pipeline_gui.py
@@ -1138,6 +1138,7 @@ class PipelineFrame(EelbrainFrame):
         else:
             rows = [self._row(i) for i in range(n)]
             self.SetStatusText(self._current_task().status_bar(rows, self._layout))
+        self._compute_btn.Enable(not self._n_loading)
 
     # ------------------------------------------------------------------
     # Background status refresh
@@ -1150,6 +1151,7 @@ class PipelineFrame(EelbrainFrame):
         self._list.DeleteAllItems()
         self._n_loading = 0
         self.SetStatusText("Loading…")
+        self._compute_btn.Disable()  # until every row is in, so that one click queues every missing row
 
         if task.shows_epoch:
             if epoch_rejection is None:
@@ -1315,10 +1317,6 @@ class PipelineFrame(EelbrainFrame):
         """
         if self._worker_active:
             return
-        # Invalidate any running refresh so both threads don't touch the
-        # pipeline concurrently.
-        self._refresh_token = object()
-
         token = object()
         self._compute_token = token
         self._n_done = 0

--- a/eelbrain/_wxgui/select_channels.py
+++ b/eelbrain/_wxgui/select_channels.py
@@ -780,7 +780,7 @@ class Frame(NavigableFrame, FileFrame):
         vmin, vmax = cbar.mappable.get_clim()
         cbar.set_ticks([vmin, (vmin + vmax) / 2, vmax])
 
-    def _mark_bad_on_topo(self, topo_plot: AxTopomap):
+    def _mark_bad_on_topo(self, topo_plot: AxTopomap) -> None:
         """Set the red × marks for bad channels on a topomap.
 
         Marks are always resolved against the topomap's own sensor dimension,

--- a/eelbrain/_wxgui/select_channels.py
+++ b/eelbrain/_wxgui/select_channels.py
@@ -34,6 +34,9 @@ from .select_epochs import VLimDialog
 
 DEFAULT_WINDOW = 30.0  # seconds
 
+# Topomap columns, in display order (one group of three per channel type)
+TOPO_LABELS = ('Cursor', 'Neighbor corr raw', 'Neighbor corr clean')
+
 _EVENT_COLORS = [c for c in UNAMBIGUOUS_COLORS.values()]
 
 TEST_MODE = False
@@ -267,8 +270,10 @@ class Frame(NavigableFrame, FileFrame):
     * Bad channels are shown as red dotted lines in butterfly plots and
       as red ``x`` marks in topomaps.
     * The cursor topomap updates in real time as you move the mouse.
-    * The "NC (clean)" topomap recomputes neighbor correlation after each
-      bad-channel change.
+    * The "Neighbor corr clean" topomap recomputes neighbor correlation after
+      each bad-channel change, omitting the bad channels; those channels are
+      therefore absent from it (no sensor dot and no ``x`` mark), while the
+      "Neighbor corr raw" map always shows all channels.
 
     *Keyboard shortcuts* in addition to the ones in the menu:
 
@@ -327,7 +332,6 @@ class Frame(NavigableFrame, FileFrame):
         self._cursor_topos: list[AxTopomap] = []
         self._static_nc_topos: list[AxTopomap] = []
         self._dynamic_nc_topos: list[AxTopomap] = []
-        self._topo_axes: list = []
         self._cursor_cbars: list = []        # Colorbar per cursor topo (rescales with cursor)
         self._cursor_cbar_axes: list = []    # their axes, for blitted redraws
         self._events_ax = None
@@ -647,21 +651,16 @@ class Frame(NavigableFrame, FileFrame):
         self._cursor_topos = []
         self._static_nc_topos = []
         self._dynamic_nc_topos = []
-        self._topo_axes = []
         self._cursor_cbars = []
         self._cursor_cbar_axes = []
 
-        topo_groups = [
-            ('Cursor', self._cursor_topos),
-            ('Neighbor corr raw', self._static_nc_topos),
-            ('Neighbor corr clean', self._dynamic_nc_topos),
-        ]
+        topo_lists = [self._cursor_topos, self._static_nc_topos, self._dynamic_nc_topos]
 
         for i_type, (ch_type, ndvar, picks) in enumerate(doc.ndvars_by_type):
             sensor = ndvar.sensor
             display_unit, scale = ch_type_scale(ch_type)
             nc_raw_topo = None  # provides the shared color scale/colorbar for the NC pair
-            for j_group, (label, topo_list) in enumerate(topo_groups):
+            for j_group, topo_list in enumerate(topo_lists):
                 if j_group == 0:
                     map_x = cursor_map_x[i_type]
                 elif j_group == 1:
@@ -673,58 +672,70 @@ class Frame(NavigableFrame, FileFrame):
                 )
                 ax.ch_type = ch_type
                 ax.topo_group = j_group
-                self._topo_axes.append(ax)
 
-                # Initial data for this topo; cursor in display units, NC unitless
                 if j_group == 0:
+                    # Cursor topo: display units, own colorbar that rescales with the cursor
                     d = raw[picks, 0:1][0][:, 0] * scale
                     topo_ndvar = NDVar(d, (sensor,), name=ch_type, info=ndvar.info)
-                    cbar_label = display_unit or ch_type
-                    interpolation = 'linear'
                     vlims = {ndvar.info.get('meas'): (-vlim_display, vlim_display)}
-                else:
-                    # NC raw uses the static map; NC clean omits bad channels
-                    if j_group == 1:
-                        topo_ndvar = doc.nc_static.get(ch_type)
-                    else:
-                        topo_ndvar = doc.compute_nc_dynamic(ch_type, ndvar)
-                    if topo_ndvar is None:
-                        topo_ndvar = NDVar(np.zeros(len(sensor)), (sensor,), name=ch_type)
-                    cbar_label = 'r'
-                    interpolation = 'nearest'
-                    vlims = {'r': (-1, 1)}
-
-                layers = AxisData([DataLayer(topo_ndvar, PlotType.IMAGE)])
-                p = AxTopomap(ax, layers, vlims=vlims, interpolation=interpolation, clip='even')
-                ax.text(0.5, 0.0, f"{label} ({ch_type})", transform=ax.transAxes,
-                        ha='center', va='bottom', fontsize=7)
-
-                if j_group == 0:
-                    # Cursor topo: own colorbar that rescales with the cursor
+                    p = self._plot_topo(ax, topo_ndvar, TOPO_LABELS[0], ch_type, vlims, 'linear')
                     cbar_ax = self.figure.add_axes(
                         (cursor_cbar_x[i_type], topo_bottom, cbar_w, topo_h),
                     )
-                    cbar = self._add_topo_colorbar(p, cbar_ax, cbar_label)
+                    cbar = self._add_topo_colorbar(p, cbar_ax, display_unit or ch_type)
                     self._cursor_cbars.append(cbar)
                     self._cursor_cbar_axes.append(cbar_ax)
                 elif j_group == 1:
-                    # NC raw defines the shared color scale; colorbar drawn with the clean topo
+                    # NC raw: static; defines the color scale shared with the clean map
+                    topo_ndvar = doc.nc_static.get(ch_type)
+                    if topo_ndvar is None:
+                        topo_ndvar = NDVar(np.zeros(len(sensor)), (sensor,), name=ch_type)
+                    p = self._plot_topo(ax, topo_ndvar, TOPO_LABELS[1], ch_type, {'r': (-1, 1)}, 'nearest')
                     nc_raw_topo = p
                 else:
                     # NC clean: share the raw NC color scale and a single colorbar
+                    p = self._plot_nc_clean(ax, ch_type, ndvar)
                     cbar_ax = self.figure.add_axes(
                         (nc_cbar_x[i_type], topo_bottom, cbar_w, topo_h),
                     )
-                    self._add_topo_colorbar(nc_raw_topo, cbar_ax, cbar_label)
+                    self._add_topo_colorbar(nc_raw_topo, cbar_ax, 'r')
 
-                # Mark bad channels with red ×
-                if doc.bad_channels:
-                    self._mark_bad_on_topo(p, sensor, doc.bad_channels)
-
+                self._mark_bad_on_topo(p)
                 topo_list.append(p)
 
         self.canvas.store_canvas()
         self.canvas.draw()
+
+    def _plot_topo(
+            self,
+            ax,
+            data: NDVar,
+            label: str,
+            ch_type: str,
+            vlims: dict,
+            interpolation: str,
+    ) -> AxTopomap:
+        """Plot a topomap on ``ax``, replacing anything previously plotted there."""
+        ax.clear()
+        layers = AxisData([DataLayer(data, PlotType.IMAGE)])
+        p = AxTopomap(ax, layers, vlims=vlims, interpolation=interpolation, clip='even')
+        ax.text(0.5, 0.0, f"{label} ({ch_type})", transform=ax.transAxes, ha='center', va='bottom', fontsize=7)
+        return p
+
+    def _plot_nc_clean(self, ax, ch_type: str, ndvar: NDVar) -> AxTopomap:
+        """(Re-)plot the clean neighbor-correlation topomap for ``ch_type`` on ``ax``.
+
+        Neighbor correlation is recomputed on good channels only, so the sensor
+        dimension of the data shrinks as channels are marked bad.  An
+        :class:`AxTopomap` derives its sensor layout (markers, clip outline) from
+        the data at construction and does not update it in ``set_data()``, so the
+        map is rebuilt rather than updated; that keeps the sensor markers and the
+        bad-channel marks consistent with the data that is actually shown.
+        """
+        data = self.doc.compute_nc_dynamic(ch_type, ndvar)
+        if data is None:
+            data = NDVar(np.zeros(len(ndvar.sensor)), (ndvar.sensor,), name=ch_type)
+        return self._plot_topo(ax, data, TOPO_LABELS[2], ch_type, {'r': (-1, 1)}, 'nearest')
 
     def _add_topo_colorbar(self, topo_plot: AxTopomap, cbar_ax, label: str):
         """Attach a thin vertical colorbar (with unit label) to a topomap."""
@@ -740,11 +751,16 @@ class Frame(NavigableFrame, FileFrame):
         vmin, vmax = cbar.mappable.get_clim()
         cbar.set_ticks([vmin, (vmin + vmax) / 2, vmax])
 
-    def _mark_bad_on_topo(self, topo_plot: AxTopomap, sensor, bad: set[str]):
-        """Add red × marks at bad channel positions on a topomap."""
-        bad_idx = [i for i, n in enumerate(sensor.names) if n in bad]
-        if bad_idx:
-            topo_plot.sensors.mark_sensors(bad_idx, color='red', marker='x', size=30, zorder=10)
+    def _mark_bad_on_topo(self, topo_plot: AxTopomap):
+        """Set the red × marks for bad channels on a topomap.
+
+        Marks are always resolved against the topomap's own sensor dimension,
+        which for the clean neighbor-correlation map contains good channels only.
+        """
+        topo_plot.sensors.mark_sensors(None)  # clear
+        bad = [name for name in topo_plot.sensors.sensors.names if name in self.doc.bad_channels]
+        if bad:
+            topo_plot.sensors.mark_sensors(bad, color='red', marker='x', size=30, zorder=10)
 
     def _update_window(self):
         """Update butterfly and events display for the current time window."""
@@ -826,8 +842,6 @@ class Frame(NavigableFrame, FileFrame):
 
     def _update_bad_channels(self):
         """Called by Document when bad channels change; updates line styles and topos."""
-        bad = self.doc.bad_channels
-
         # Update butterfly line colors and styles
         for ch_type, ndvar, picks in self.doc.ndvars_by_type:
             lc = self._butterfly_lc.get(ch_type)
@@ -837,21 +851,14 @@ class Frame(NavigableFrame, FileFrame):
             lc.set_color(colors)
             lc.set_linestyle(linestyles)
 
-        # Update sensor marks on all topos
-        for p, (ch_type, ndvar, picks) in zip(
-                self._cursor_topos + self._static_nc_topos + self._dynamic_nc_topos,
-                list(self.doc.ndvars_by_type) * 3,
-        ):
-            sensor = ndvar.sensor
-            p.sensors.mark_sensors(None)  # clear
-            if bad:
-                self._mark_bad_on_topo(p, sensor, bad)
-
-        # Recompute and update dynamic NC topos
+        # Rebuild the clean NC topos (their sensor dimension follows the good channels)
         for i_type, (ch_type, ndvar, picks) in enumerate(self.doc.ndvars_by_type):
-            nc_dyn = self.doc.compute_nc_dynamic(ch_type, ndvar)
-            if nc_dyn is not None and i_type < len(self._dynamic_nc_topos):
-                self._dynamic_nc_topos[i_type].set_data([nc_dyn])
+            ax = self._dynamic_nc_topos[i_type].ax
+            self._dynamic_nc_topos[i_type] = self._plot_nc_clean(ax, ch_type, ndvar)
+
+        # Update sensor marks on all topos
+        for p in self._cursor_topos + self._static_nc_topos + self._dynamic_nc_topos:
+            self._mark_bad_on_topo(p)
 
         self.canvas.draw()
         # Refresh the blit background so cursor-topo / window updates stay valid
@@ -873,7 +880,7 @@ class Frame(NavigableFrame, FileFrame):
             d = raw[picks, t_idx:t_idx + 1][0][:, 0] * scale
             cursor_ndvar = NDVar(d, (ndvar.sensor,), name=ch_type, info=ndvar.info)
             self._cursor_topos[i_type].set_data([cursor_ndvar])
-            redraw_axes.append(self._topo_axes[i_type * 3])
+            redraw_axes.append(self._cursor_topos[i_type].ax)
 
         if redraw_axes:
             self.canvas.redraw(redraw_axes)
@@ -970,6 +977,7 @@ class Frame(NavigableFrame, FileFrame):
         if entry is None:
             return
         ch_type, ndvar, picks = entry
+        title = f"{TOPO_LABELS[group]} ({ch_type})"
         if group == 0:
             t = self._cursor_t if self._cursor_t is not None else self.t_start
             raw = self.doc.raw
@@ -977,13 +985,11 @@ class Frame(NavigableFrame, FileFrame):
             _, scale = ch_type_scale(ch_type)
             d = raw[picks, t_idx:t_idx + 1][0][:, 0] * scale
             data = NDVar(d, (ndvar.sensor,), name=ch_type, info=ndvar.info)
-            title = f"Cursor ({ch_type}) t={t:.3f} s"
+            title = f"{title} t={t:.3f} s"
         elif group == 1:
             data = self.doc.nc_static.get(ch_type)
-            title = f"Neighbor corr raw ({ch_type})"
         else:
             data = self.doc.compute_nc_dynamic(ch_type, ndvar)
-            title = f"Neighbor corr clean ({ch_type})"
         if data is None:
             return
         plot.Topomap(data, sensorlabels='name', axw=9, title=title)

--- a/eelbrain/_wxgui/select_channels.py
+++ b/eelbrain/_wxgui/select_channels.py
@@ -10,6 +10,7 @@
 #  - issues commands to Model
 
 import mne
+from matplotlib.axes import Axes
 from matplotlib.collections import LineCollection
 import numpy as np
 import pandas as pd
@@ -709,21 +710,42 @@ class Frame(NavigableFrame, FileFrame):
 
     def _plot_topo(
             self,
-            ax,
+            ax: Axes,
             data: NDVar,
             label: str,
             ch_type: str,
             vlims: dict,
             interpolation: str,
     ) -> AxTopomap:
-        """Plot a topomap on ``ax``, replacing anything previously plotted there."""
+        """Plot a topomap on ``ax``, replacing anything previously plotted there.
+
+        Parameters
+        ----------
+        ax
+            Axes to draw on.
+        data
+            Sensor data to map.
+        label
+            Map title, one of :data:`TOPO_LABELS`.
+        ch_type
+            Channel type, appended to the title.
+        vlims
+            ``{meas: (vmin, vmax)}`` color scale.
+        interpolation
+            Image interpolation, as for :class:`AxTopomap`.
+        """
         ax.clear()
         layers = AxisData([DataLayer(data, PlotType.IMAGE)])
         p = AxTopomap(ax, layers, vlims=vlims, interpolation=interpolation, clip='even')
         ax.text(0.5, 0.0, f"{label} ({ch_type})", transform=ax.transAxes, ha='center', va='bottom', fontsize=7)
         return p
 
-    def _plot_nc_clean(self, ax, ch_type: str, ndvar: NDVar) -> AxTopomap:
+    def _plot_nc_clean(
+            self,
+            ax: Axes,
+            ch_type: str,
+            ndvar: NDVar,
+    ) -> AxTopomap:
         """(Re-)plot the clean neighbor-correlation topomap for ``ch_type`` on ``ax``.
 
         Neighbor correlation is recomputed on good channels only, so the sensor

--- a/eelbrain/_wxgui/select_channels.py
+++ b/eelbrain/_wxgui/select_channels.py
@@ -218,7 +218,11 @@ class Document(FileDocument):
         return frozenset(new_bad)
 
     def compute_nc_dynamic(self, ch_type: str, ndvar: NDVar) -> NDVar | None:
-        """NC recomputed with bad channels omitted, for a smooth interpolated map."""
+        """NC recomputed with bad channels omitted, for a smooth interpolated map.
+
+        Falls back to the static map (all channels) when the correlation can not be
+        mapped: without bad channels, with fewer than 4 good channels, or on failure.
+        """
         static = self.nc_static.get(ch_type)
         bad = self.bad_channels
         if static is None:
@@ -275,7 +279,9 @@ class Frame(NavigableFrame, FileFrame):
     * The "Neighbor corr clean" topomap recomputes neighbor correlation after
       each bad-channel change, omitting the bad channels; those channels are
       therefore absent from it (no sensor dot and no ``x`` mark), while the
-      "Neighbor corr raw" map always shows all channels.
+      "Neighbor corr raw" map always shows all channels. With fewer than 4
+      good channels the clean map falls back to the raw map, since fewer
+      sensors can not be laid out as a map.
 
     *Keyboard shortcuts* in addition to the ones in the menu:
 

--- a/eelbrain/_wxgui/select_channels.py
+++ b/eelbrain/_wxgui/select_channels.py
@@ -223,7 +223,8 @@ class Document(FileDocument):
         if static is None:
             return None
         good = [n for n in ndvar.sensor.names if n not in bad]
-        if len(good) == len(ndvar.sensor) or len(good) < 2:
+        # fewer than 4 sensors can not be laid out as a map (the 2-D projection fits a sphere)
+        if len(good) == len(ndvar.sensor) or len(good) < 4:
             return static
         try:
             return neighbor_correlation(ndvar.sub(sensor=good))

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -74,14 +74,6 @@ def test_task_layout():
     assert TASKS_BY_NAME['ica'].layout(p, 'raw') != TASKS_BY_NAME['ica'].layout(pipeline(sessions=2), 'raw')
 
 
-def test_layout_iter_arg():
-    "Rows are iterated over exactly the key fields the columns were built from"
-    p = pipeline(sessions=2)
-    assert TASKS_BY_NAME['ica'].layout(p, 'raw').iter_arg == ['subject', 'session']
-    assert TASKS_BY_NAME['mri'].layout(p, None).iter_arg == 'subject'
-    assert TASKS_BY_NAME['coreg'].layout(p, None).iter_arg == ['subject', 'session']
-
-
 def test_task_key_fields():
     "Key fields expand with the state fields that vary in the experiment"
     bad_chs, ica, coreg = TASKS_BY_NAME['bad_chs'], TASKS_BY_NAME['ica'], TASKS_BY_NAME['coreg']

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -521,6 +521,29 @@ def test_refresh_shows_the_rows_before_their_status(monkeypatch):
     assert [args[0] for args in posted] == [frame._populate_table, frame._fill_row, frame._fill_row, frame._show_error]
     assert 'RuntimeError: first' in posted[-1][1]
 
+    # a second pass that fails outright is reported, and the table is settled afterwards
+    posted.clear()
+    frame._iter_rows = lambda token_, scope, combos: (_ for _ in ()).throw(RuntimeError("no rows"))
+    frame._refresh_thread(token, _ICA_SCOPE)
+    assert [args[0] for args in posted] == [frame._populate_table, frame._show_error, frame._end_refresh]
+    assert posted[-1] == (frame._end_refresh, token)
+
+
+def test_end_refresh_settles_the_rows_a_failed_pass_left_loading():
+    "Rows the second pass never filled in are shown as errors, so the table stops loading"
+    task = TASKS_BY_NAME['ica']
+    layout = _layout('ica')
+    rows = [('R01', 'selected', '30', '2'), task.missing_row(('R02',), layout, pipeline_gui.LOADING)]
+    frame = _table_frame('ica', rows)
+    texts = []
+    frame.__dict__.update(_refresh_token='TOKEN', _n_loading=1, _refresh_status_bar=lambda: texts.append(frame._n_loading))
+    frame._end_refresh('OTHER')  # a superseded refresh leaves the new table alone
+    assert frame._list.rows == rows
+    frame._end_refresh('TOKEN')
+    assert frame._list.rows == [rows[0], ('R02', pipeline_gui.ERROR, PLACEHOLDER, PLACEHOLDER)]
+    assert frame._list.colours == {1: wx.RED}
+    assert texts == [0]
+
 
 def test_iter_rows_yields_a_stale_ica_row():
     "A stale ICA is shown as the user's choice, and does not abort the pass"

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -449,7 +449,7 @@ def test_refresh_holds_the_pipeline_lock(monkeypatch):
         _pipeline_lock=threading.Lock(),
         _refresh_token=token,
         _iter_combos=lambda scope: locked.append(frame._pipeline_lock.locked()) or iter([('R01',)]),
-        _iter_rows=lambda token_, scope: locked.append(frame._pipeline_lock.locked()) or iter([(('R01',), ('R01', 'selected', '30', '2'), 'SPEC')]),
+        _iter_rows=lambda token_, scope, combos: locked.append(frame._pipeline_lock.locked()) or iter([(('R01',), ('R01', 'selected', '30', '2'), 'SPEC')]),
     )
     frame._refresh_thread(token, _ICA_SCOPE)
     assert locked == [True, True]
@@ -469,11 +469,14 @@ def test_refresh_shows_the_rows_before_their_status(monkeypatch):
         _pipeline_lock=threading.Lock(),
         _refresh_token=token,
         _iter_combos=lambda scope: iter([('R01',), ('R02',)]),
-        _iter_rows=lambda token_, scope: iter(rows),
+        _iter_rows=lambda token_, scope, combos: walked.append(combos) or iter(rows),
     )
+    walked = []
     frame._refresh_thread(token, _ICA_SCOPE)
     # the table goes up first, with every row still loading
     assert posted[0] == (frame._populate_table, [task.missing_row(combo, _ICA_LAYOUT, pipeline_gui.LOADING) for combo, _, _ in rows], token)
+    # the second pass resolves the rows the first pass found, rather than walking them again
+    assert walked == [[('R01',), ('R02',)]]
     # then one update per row, at the position the first pass put it
     assert posted[1] == (frame._fill_row, token, _ICA_SCOPE, 0, ('R01',), ('R01', 'selected', '30', '2'), 'SPEC-1')
     assert posted[2] == (frame._fill_row, token, _ICA_SCOPE, 1, ('R02',), ('R02', 'no ICA', PLACEHOLDER, PLACEHOLDER), 'SPEC-2')

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -349,7 +349,8 @@ def test_status_bar_shows_progress_while_rows_load():
     rows = [('R01', 'selected', '30', '2'), *(task.missing_row((subject,), layout, pipeline_gui.LOADING) for subject in ('R02', 'R03'))]
     frame = _table_frame('ica', rows)
     texts = []
-    frame.__dict__.update(SetStatusText=texts.append, _n_loading=2, _refresh_token='TOKEN', _job_specs={})
+    enabled = []
+    frame.__dict__.update(SetStatusText=texts.append, _n_loading=2, _refresh_token='TOKEN', _job_specs={}, _compute_btn=SimpleNamespace(Enable=enabled.append))
     frame._refresh_status_bar()
     assert texts == ["Loading… 1 / 3"]
 
@@ -359,6 +360,8 @@ def test_status_bar_shows_progress_while_rows_load():
     assert texts[-1] == "Loading… 2 / 3"
     frame._fill_row('TOKEN', 'SCOPE', 2, ('R03',), ('R03', 'selected', '30', '2'), None)
     assert texts[-1] == "2 / 3 subjects · ICA selected  (1 missing ICA file)"
+    # the compute button waits for the last row, so that one click queues every missing row
+    assert enabled == [False, False, True]
 
 
 def test_set_row_result_writes_status_details_and_colour():

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -364,6 +364,17 @@ def test_status_bar_shows_progress_while_rows_load():
     assert enabled == [False, False, True]
 
 
+def test_activate_row_waits_for_the_row_to_load():
+    "A double-click on a row whose columns are still placeholders does nothing"
+    layout = _layout('coreg')
+    frame = _table_frame('coreg', [TASKS_BY_NAME['coreg'].missing_row(('R01', 's1'), layout, pipeline_gui.LOADING), ('R02', 's1', 'R02', 'missing')])
+    activated = []
+    frame._activate_item = lambda idx, subject, task: activated.append(idx)
+    frame._activate_row(0)
+    frame._activate_row(1)
+    assert activated == [1]
+
+
 def test_set_row_result_writes_status_details_and_colour():
     "One row write for every task, addressed through the cached layout"
     frame = _table_frame('ica', [('R01', 'queued', PLACEHOLDER, PLACEHOLDER)])

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -310,17 +310,53 @@ def test_populate_table_fits_the_rows_to_the_columns():
         for combo, n_excluded in [(('R01', 's0'), '2'), (('R02', 's0'), '0'), (('R03', 's1'), None)]
     ]
     frame = _table_frame('ica', sessions=2)
-    frame.__dict__.update(_refresh_token='TOKEN', _job_specs={}, _refresh_status_bar=lambda: None)
-    frame._populate_table(rows, {'specs': True}, 'TOKEN')
+    frame.__dict__.update(_refresh_token='TOKEN', _job_specs={'stale': True}, _refresh_status_bar=lambda: None)
+    frame._populate_table(rows, 'TOKEN')
     assert frame._list.rows == rows
-    assert frame._job_specs == {'specs': True}
+    assert frame._job_specs == {}  # the previous table's specs are gone
     # only the ICA with no rejected component is coloured
     assert frame._list.colours == {0: wx.NullColour, 1: wx.RED, 2: wx.NullColour}
 
-    # a result arriving for a stale token is dropped, specs and all
-    frame._populate_table([], {}, 'OTHER')
+    # a table arriving for a stale token is dropped
+    frame._populate_table([], 'OTHER')
     assert frame._list.rows == rows
-    assert frame._job_specs == {'specs': True}
+
+
+def test_fill_row_writes_one_resolved_row():
+    "The second refresh pass fills a loading row in, addressed by its position"
+    task = TASKS_BY_NAME['ica']
+    layout = _layout('ica')
+    loading = [task.missing_row((subject,), layout, pipeline_gui.LOADING) for subject in ('R01', 'R02')]
+    frame = _table_frame('ica', loading)
+    frame.__dict__.update(_refresh_token='TOKEN', _job_specs={}, _refresh_status_bar=lambda: None, _table_scope=lambda: 'SCOPE')
+    frame._fill_row('TOKEN', 'SCOPE', 1, ('R02',), ('R02', 'selected', '30', '2'), 'SPEC')
+    assert frame._list.rows == [loading[0], ('R02', 'selected', '30', '2')]
+    assert frame._job_specs == {('SCOPE', ('R02',)): 'SPEC'}
+
+    # a row arriving for a stale token, for a row that is gone, or for a combo that no
+    # longer sits at that position is dropped, spec and all
+    for token, index, combo in [('OTHER', 0, ('R01',)), ('TOKEN', 2, ('R03',)), ('TOKEN', 0, ('R03',))]:
+        frame._fill_row(token, 'SCOPE', index, combo, (*combo, 'selected', '30', '9'), 'DROPPED')
+    assert frame._list.rows == [loading[0], ('R02', 'selected', '30', '2')]
+    assert frame._job_specs == {('SCOPE', ('R02',)): 'SPEC'}
+
+
+def test_status_bar_shows_progress_while_rows_load():
+    "A partly filled table reports its progress rather than an undercount"
+    task = TASKS_BY_NAME['ica']
+    layout = _layout('ica')
+    rows = [('R01', 'selected', '30', '2'), *(task.missing_row((subject,), layout, pipeline_gui.LOADING) for subject in ('R02', 'R03'))]
+    frame = _table_frame('ica', rows)
+    texts = []
+    frame.__dict__.update(SetStatusText=texts.append)
+    frame._refresh_status_bar()
+    assert texts == ["Loading… 1 / 3"]
+
+    # once no row is loading any more the task's own summary takes over
+    frame._list.SetItem(1, 1, 'no ICA')
+    frame._list.SetItem(2, 1, 'selected')
+    frame._refresh_status_bar()
+    assert texts[-1] == "2 / 3 subjects · ICA selected  (1 missing ICA file)"
 
 
 def test_set_row_result_writes_status_details_and_colour():
@@ -411,16 +447,48 @@ def test_compute_job_holds_the_pipeline_lock_except_for_the_fit():
 
 
 def test_refresh_holds_the_pipeline_lock(monkeypatch):
-    "The refresh walk never runs while the worker is loading or saving"
+    "Neither refresh pass ever runs while the worker is loading or saving"
     monkeypatch.setattr(pipeline_gui.wx, 'CallAfter', lambda *args: posted.append(args))
     posted = []
     locked = []
+    token = object()
     frame = _frame(
         _pipeline=pipeline(),
         _pipeline_lock=threading.Lock(),
-        _compute_rows=lambda token, scope: locked.append(frame._pipeline_lock.locked()) or ([], {}),
+        _refresh_token=token,
+        _iter_combos=lambda scope: locked.append(frame._pipeline_lock.locked()) or iter([('R01',)]),
+        _iter_rows=lambda token_, scope: locked.append(frame._pipeline_lock.locked()) or iter([(('R01',), ('R01', 'selected', '30', '2'), 'SPEC')]),
     )
-    frame._refresh_thread(object(), _ICA_SCOPE)
-    assert locked == [True]
+    frame._refresh_thread(token, _ICA_SCOPE)
+    assert locked == [True, True]
     assert not frame._pipeline_lock.locked()  # released before the table update is posted
     assert posted
+
+
+def test_refresh_shows_the_rows_before_their_status(monkeypatch):
+    "The table is posted from the first pass, then filled in row by row"
+    monkeypatch.setattr(pipeline_gui.wx, 'CallAfter', lambda *args: posted.append(args))
+    posted = []
+    token = object()
+    task = TASKS_BY_NAME['ica']
+    rows = [(('R01',), ('R01', 'selected', '30', '2'), 'SPEC-1'), (('R02',), ('R02', 'no ICA', PLACEHOLDER, PLACEHOLDER), 'SPEC-2')]
+    frame = _frame(
+        _pipeline=pipeline(),
+        _pipeline_lock=threading.Lock(),
+        _refresh_token=token,
+        _iter_combos=lambda scope: iter([('R01',), ('R02',)]),
+        _iter_rows=lambda token_, scope: iter(rows),
+    )
+    frame._refresh_thread(token, _ICA_SCOPE)
+    # the table goes up first, with every row still loading
+    assert posted[0] == (frame._populate_table, [task.missing_row(combo, _ICA_LAYOUT, pipeline_gui.LOADING) for combo, _, _ in rows], token)
+    # then one update per row, at the position the first pass put it
+    assert posted[1] == (frame._fill_row, token, _ICA_SCOPE, 0, ('R01',), ('R01', 'selected', '30', '2'), 'SPEC-1')
+    assert posted[2] == (frame._fill_row, token, _ICA_SCOPE, 1, ('R02',), ('R02', 'no ICA', PLACEHOLDER, PLACEHOLDER), 'SPEC-2')
+    assert len(posted) == 3
+
+    # a task switch between the two passes drops the table rather than paying for its rows
+    posted.clear()
+    frame._refresh_token = object()
+    frame._refresh_thread(token, _ICA_SCOPE)
+    assert posted == []

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -119,6 +119,8 @@ def test_task_status_bar():
     assert TASKS_BY_NAME['ica'].status_bar([('R01', 'a', 'selected', '30', '2'), ('R02', 'b', 'no ICA', PLACEHOLDER, PLACEHOLDER)], _layout('ica', sessions=2)) == "1 / 2 recordings · ICA selected  (1 missing ICA file)"
 
     assert TASKS_BY_NAME['epoch_rej'].status_bar([('R01', 'done', '100', '5'), ('R02', 'missing', PLACEHOLDER, PLACEHOLDER)], _layout('epoch_rej')) == "1 / 2 subjects · epoch rejection done"
+    # a row whose artifact could not be inspected is reported for every task
+    assert TASKS_BY_NAME['epoch_rej'].status_bar([('R01', 'done', '100', '5'), ('R02', pipeline_gui.ERROR, PLACEHOLDER, PLACEHOLDER)], _layout('epoch_rej')) == "1 / 2 subjects · epoch rejection done  (1 error)"
     # epoch rejection is per subject, so a second session does not change the noun
     assert TASKS_BY_NAME['epoch_rej'].status_bar([('R01', 'done', '100', '5')], _layout('epoch_rej', sessions=2)) == "1 / 1 subjects · epoch rejection done"
 
@@ -134,7 +136,6 @@ def test_task_status_bar():
 
 def test_task_row_colour():
     "Rows needing attention are red, rows that are not actionable are grey"
-    assert TASKS_BY_NAME['bad_chs'].row_colour(('R01', 'error', PLACEHOLDER), _layout('bad_chs')) is wx.RED
     assert TASKS_BY_NAME['bad_chs'].row_colour(('R01', 'done', '3'), _layout('bad_chs')) is None
 
     # an ICA without a single rejected component is almost always an oversight

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -2,12 +2,30 @@ import threading
 from types import SimpleNamespace
 
 import numpy as np
+import wx
 
 from eelbrain import Dataset, Var
 from eelbrain._exceptions import ConfigurationError, DataError
+from eelbrain._experiment.epoch_rejection import ChannelModelRejection, ManualRejection
 from eelbrain._experiment.exceptions import FileMissingError
 from eelbrain._wxgui import pipeline_gui
-from eelbrain._wxgui.pipeline_gui import PipelineFrame, _format_user_error
+from eelbrain._wxgui.pipeline_gui import COMMON_BRAIN_ROW, GREY, PLACEHOLDER, TASKS, TASKS_BY_NAME, Layout, PipelineFrame, _format_user_error
+
+
+def pipeline(
+        sessions: int = 1,
+        tasks: int = 1,
+        runs: int = 1,
+        concatenate_runs: bool = True,
+) -> SimpleNamespace:
+    """Minimal stand-in exposing the pipeline attributes the tasks read."""
+    return SimpleNamespace(
+        _sessions=[f's{i}' for i in range(sessions)],
+        _tasks=[f't{i}' for i in range(tasks)],
+        _runs=[f'{i}' for i in range(runs)],
+        _raw={'raw': SimpleNamespace(_concatenate_runs=concatenate_runs)},
+        _epoch_rejection={'manual': ManualRejection(), 'auto': None},
+    )
 
 
 def test_format_user_error():
@@ -31,42 +49,203 @@ def test_format_user_error():
     assert _format_user_error(RuntimeError("programmer error")) is None
 
 
-def test_result_columns():
-    "The one piece of per-task logic left in the unified job queue"
-    ica = SimpleNamespace(n_components_=12, exclude=[0, 3])
-    assert PipelineFrame._result_columns('ica', ica) == ('12', '2')
+def test_task_layout():
+    "Column layout, and the Status index derived from it"
+    p = pipeline()
+    assert TASKS_BY_NAME['bad_chs'].layout(p, 'raw').columns == (('Subject', 180), ('Status', 110), ('N bad', 90))
+    assert TASKS_BY_NAME['ica'].layout(p, 'raw').columns == (('Subject', 180), ('Status', 110), ('Components', 110), ('Rejected', 90))
+    assert TASKS_BY_NAME['epoch_rej'].layout(p, 'raw').columns == (('Subject', 180), ('Status', 110), ('N total', 90), ('N rejected', 90))
+    assert TASKS_BY_NAME['mri'].layout(p, None).columns == (('Subject', 180), ('MRI subject', 170), ('Status', 130))
+    assert TASKS_BY_NAME['coreg'].layout(p, None).columns == (('Subject', 140), ('Session', 80), ('MRI subject', 140), ('Status', 110))
 
+    # Status sits after the key fields for the per-recording tasks, but further
+    # right for MRI/Coregistration, whose leading columns are display-only
+    for task, raw_name, status_col in [(TASKS_BY_NAME['bad_chs'], 'raw', 1), (TASKS_BY_NAME['mri'], None, 2), (TASKS_BY_NAME['coreg'], None, 3)]:
+        layout = task.layout(p, raw_name)
+        assert layout.status_col == status_col
+        assert layout.columns[status_col][0] == 'Status'
+        assert len(layout.columns) == status_col + 1 + len(task.detail_columns)
+
+    # a layout is a value: it compares equal across derivations, so it can identify
+    # a table in a job's scope (see PipelineFrame._table_scope)
+    assert TASKS_BY_NAME['ica'].layout(p, 'raw') == TASKS_BY_NAME['ica'].layout(pipeline(), 'raw')
+    assert TASKS_BY_NAME['ica'].layout(p, 'raw') != TASKS_BY_NAME['ica'].layout(pipeline(sessions=2), 'raw')
+
+
+def test_layout_iter_arg():
+    "Rows are iterated over exactly the key fields the columns were built from"
+    p = pipeline(sessions=2)
+    assert TASKS_BY_NAME['ica'].layout(p, 'raw').iter_arg == ['subject', 'session']
+    assert TASKS_BY_NAME['mri'].layout(p, None).iter_arg == 'subject'
+    assert TASKS_BY_NAME['coreg'].layout(p, None).iter_arg == ['subject', 'session']
+
+
+def test_task_key_fields():
+    "Key fields expand with the state fields that vary in the experiment"
+    bad_chs, ica, coreg = TASKS_BY_NAME['bad_chs'], TASKS_BY_NAME['ica'], TASKS_BY_NAME['coreg']
+    assert bad_chs.key_fields(pipeline(), 'raw') == ('subject',)
+    assert bad_chs.key_fields(pipeline(sessions=2, runs=3), 'raw') == ('subject', 'session', 'run')
+    assert bad_chs.key_fields(pipeline(sessions=2, tasks=2, runs=2), 'raw') == ('subject', 'session', 'task', 'run')
+
+    # ICA is cached per recording, but not per run when runs are concatenated
+    assert ica.key_fields(pipeline(runs=3), 'raw') == ('subject',)
+    assert ica.key_fields(pipeline(runs=3, concatenate_runs=False), 'raw') == ('subject', 'run')
+    assert ica.key_fields(pipeline(sessions=2, tasks=2), 'raw') == ('subject', 'session')  # ICA ignores task
+
+    assert coreg.key_fields(pipeline(), None) == ('subject', 'session')
+
+    # extra columns follow the key fields, so a row is exactly as wide as its columns
+    p = pipeline(sessions=2, runs=2, concatenate_runs=False)
+    layout = ica.layout(p, 'raw')
+    assert layout.columns[1:3] == (('Session', 90), ('Run', 90))
+    assert layout.status_col == len(layout.key_fields)
+
+
+def _layout(name: str, **kwargs) -> Layout:
+    "Layout of a task for a pipeline with the given fields varying"
+    task = TASKS_BY_NAME[name]
+    return task.layout(pipeline(**kwargs), 'raw' if task.shows_raw else None)
+
+
+def test_task_status_bar():
+    "Status-bar summary for each task"
+    bad_chs = _layout('bad_chs')
+    assert TASKS_BY_NAME['bad_chs'].status_bar([('R01', 'done', '3'), ('R02', 'error', PLACEHOLDER), ('R03', 'done', '0')], bad_chs) == "2 / 3 subjects · bad channels defined  (1 error)"
+    assert TASKS_BY_NAME['bad_chs'].status_bar([('R01', 'done', '3')], bad_chs) == "1 / 1 subjects · bad channels defined"
+    # bad channels are stored per recording, so with a second session the rows are
+    # recordings rather than subjects
+    assert TASKS_BY_NAME['bad_chs'].status_bar([('R01', 's0', 'done', '3'), ('R01', 's1', 'error', PLACEHOLDER)], _layout('bad_chs', sessions=2)) == "1 / 2 recordings · bad channels defined  (1 error)"
+
+    # queued and computing rows have no artifact either, so they count as missing
+    ica_rows = [('R01', 'selected', '30', '2'), ('R02', 'no ICA', PLACEHOLDER, PLACEHOLDER), ('R03', 'queued', PLACEHOLDER, PLACEHOLDER), ('R04', '⟳', PLACEHOLDER, PLACEHOLDER), ('R05', 'no data', PLACEHOLDER, PLACEHOLDER)]
+    assert TASKS_BY_NAME['ica'].status_bar(ica_rows, _layout('ica')) == "1 / 5 subjects · ICA selected  (3 missing ICA file)"
+    # one row per recording once a key field beyond subject varies
+    assert TASKS_BY_NAME['ica'].status_bar([('R01', 'a', 'selected', '30', '2'), ('R02', 'b', 'no ICA', PLACEHOLDER, PLACEHOLDER)], _layout('ica', sessions=2)) == "1 / 2 recordings · ICA selected  (1 missing ICA file)"
+
+    assert TASKS_BY_NAME['epoch_rej'].status_bar([('R01', 'done', '100', '5'), ('R02', 'missing', PLACEHOLDER, PLACEHOLDER)], _layout('epoch_rej')) == "1 / 2 subjects · epoch rejection done"
+    # epoch rejection is per subject, so a second session does not change the noun
+    assert TASKS_BY_NAME['epoch_rej'].status_bar([('R01', 'done', '100', '5')], _layout('epoch_rej', sessions=2)) == "1 / 1 subjects · epoch rejection done"
+
+    # the common brain is not a subject and stays out of the count
+    mri = _layout('mri')
+    mri_rows = [('R01', 'R01', 'ok'), ('R02', 'fsaverage', 'template'), ('R03', 'R03', 'no MRI'), (COMMON_BRAIN_ROW, 'fsaverage', 'ok')]
+    assert TASKS_BY_NAME['mri'].status_bar(mri_rows, mri) == "2 / 3 subjects · MRI available  (1 missing)"
+    assert TASKS_BY_NAME['mri'].status_bar([('R01', 'R01', 'ok'), (COMMON_BRAIN_ROW, 'fsaverage', 'missing')], mri) == "1 / 1 subjects · MRI available"
+
+    # Coregistration has two key fields but counts sessions, not recordings
+    assert TASKS_BY_NAME['coreg'].status_bar([('R01', 's1', 'R01', 'ok'), ('R02', 's1', 'R02', 'missing')], _layout('coreg')) == "1 / 2 sessions · coregistration done  (1 missing)"
+
+
+def test_task_row_colour():
+    "Rows needing attention are red, rows that are not actionable are grey"
+    assert TASKS_BY_NAME['bad_chs'].row_colour(('R01', 'error', PLACEHOLDER), _layout('bad_chs')) is wx.RED
+    assert TASKS_BY_NAME['bad_chs'].row_colour(('R01', 'done', '3'), _layout('bad_chs')) is None
+
+    # an ICA without a single rejected component is almost always an oversight
+    ica = _layout('ica')
+    assert TASKS_BY_NAME['ica'].row_colour(('R01', 'selected', '30', '0'), ica) is wx.RED
+    assert TASKS_BY_NAME['ica'].row_colour(('R01', 'selected', '30', '2'), ica) is None
+    assert TASKS_BY_NAME['ica'].row_colour(('R01', 'no ICA', PLACEHOLDER, PLACEHOLDER), ica) is None
+    # the same rule at the wider layout, addressed through the Status column
+    assert TASKS_BY_NAME['ica'].row_colour(('R01', 'a', 'selected', '30', '0'), _layout('ica', sessions=2)) is wx.RED
+
+    mri = _layout('mri')
+    assert TASKS_BY_NAME['mri'].row_colour(('R01', 'R01', 'no MRI'), mri) is wx.RED
+    assert TASKS_BY_NAME['mri'].row_colour(('R01', 'R01', 'ok'), mri) is None
+    assert TASKS_BY_NAME['mri'].row_colour((COMMON_BRAIN_ROW, 'fsaverage', 'ok'), mri) is GREY
+
+    assert TASKS_BY_NAME['coreg'].row_colour(('R01', 's1', 'R01', 'missing'), _layout('coreg')) is wx.RED
+    assert TASKS_BY_NAME['coreg'].row_colour(('R01', 's1', 'R01', 'ok'), _layout('coreg')) is None
+
+    assert TASKS_BY_NAME['epoch_rej'].row_colour(('R01', 'missing', PLACEHOLDER, PLACEHOLDER), _layout('epoch_rej')) is None
+
+
+def test_task_computable():
+    "Only tasks that can make their artifact in bulk offer the compute button"
+    p = pipeline()
+    assert [task.name for task in TASKS if task.compute_label] == ['ica', 'epoch_rej']
+    assert TASKS_BY_NAME['ica'].computable(p, None)
+    assert not TASKS_BY_NAME['mri'].computable(p, None)
+    # a ManualRejection is edited in its own GUI; only an automatic one is computed
+    p._epoch_rejection = {'manual': ManualRejection(), 'auto': ChannelModelRejection()}
+    assert TASKS_BY_NAME['epoch_rej'].computable(p, 'auto')
+    assert not TASKS_BY_NAME['epoch_rej'].computable(p, 'manual')
+    assert not TASKS_BY_NAME['epoch_rej'].computable(p, None)
+
+
+def test_task_missing_row():
+    "A row with no artifact is exactly as wide as the columns, for every task"
+    for task in TASKS:
+        layout = task.layout(pipeline(sessions=2), 'raw' if task.shows_raw else None)
+        row = task.missing_row(('R01',) * len(layout.key_fields), layout)
+        assert len(row) == len(layout.columns)
+        assert row[layout.status_col] == task.missing_status
+        # every column that is not a key field has no value to show
+        assert set(row[len(layout.key_fields):layout.status_col]) <= {PLACEHOLDER}
+        assert set(row[layout.status_col + 1:]) <= {PLACEHOLDER}
+    # an alternative status keeps the placeholders
+    assert TASKS_BY_NAME['ica'].missing_row(('R01',), _layout('ica'), 'no data') == ('R01', 'no data', PLACEHOLDER, PLACEHOLDER)
+    # MRI/Coregistration have a display-only column before Status; it is filled too
+    assert TASKS_BY_NAME['coreg'].missing_row(('R01', 's1'), _layout('coreg')) == ('R01', 's1', PLACEHOLDER, 'missing')
+
+
+def test_result_columns():
+    "The detail columns describing a freshly computed artifact"
+    ica = SimpleNamespace(n_components_=12, exclude=[0, 3])
     rej_ds = Dataset({'accept': Var(np.array([True, False, True]))})
-    assert PipelineFrame._result_columns('epoch_rej', rej_ds) == ('3', '1')
+    assert TASKS_BY_NAME['ica'].result_columns(ica) == ('12', '2')
+    assert TASKS_BY_NAME['epoch_rej'].result_columns(rej_ds) == ('3', '1')
 
     # every computable task has both status labels and a result mapping
-    assert PipelineFrame._MISSING_STATUS.keys() == PipelineFrame._DONE_STATUS.keys()
-    for kind in PipelineFrame._MISSING_STATUS:
-        assert PipelineFrame._result_columns(kind, ica if kind == 'ica' else rej_ds)
+    for task in TASKS:
+        if task.compute_label is None:
+            continue
+        assert task.missing_status and task.done_status
+        result = ica if task.name == 'ica' else rej_ds
+        assert len(task.result_columns(result)) == len(task.detail_columns)
 
 
 class _FakeList:
     "Minimal wx.ListCtrl stand-in recording the cells that were written"
 
-    def __init__(self, rows: list[tuple], n_columns: int = 3):
-        self.rows = rows
-        self.n_columns = n_columns
-        self.written = {}  # {(row, col): value}
+    def __init__(self, rows: list[tuple] = ()):
+        self.rows = [tuple(row) for row in rows]
+        self.columns = []  # [(title, width), ...] as installed
+        self.colours = {}  # {row: colour}
         self.cleared = False
+
+    def InsertColumn(self, col, label, width):
+        assert col == len(self.columns)
+        self.columns.append((label, width))
+
+    def ClearAll(self):
+        self.columns = []
+        self.rows = []
+        self.cleared = True
 
     def GetItemCount(self):
         return len(self.rows)
 
     def GetColumnCount(self):
-        return self.n_columns
+        return len(self.columns)
 
     def GetItemText(self, row, col):
-        return self.written.get((row, col), self.rows[row][col])
+        return self.rows[row][col]
+
+    def InsertItem(self, row, value):
+        assert row == len(self.rows)
+        self.rows.append((value,) + ('',) * (len(self.columns) - 1))
+        return row
 
     def SetItem(self, row, col, value):
-        self.written[row, col] = value
+        assert col < len(self.columns), f"{col=} beyond the installed columns"
+        self.rows[row] = self.rows[row][:col] + (value,) + self.rows[row][col + 1:]
+
+    def SetItemTextColour(self, row, colour):
+        self.colours[row] = colour
 
     def DeleteAllItems(self):
+        self.rows = []
         self.cleared = True
 
 
@@ -77,8 +256,85 @@ def _frame(**attrs) -> PipelineFrame:
     return frame
 
 
-_ICA_SCOPE = ('ica', 'ica', None, '1-40')
-_OTHER_SCOPE = ('ica', 'ica', None, 'ica-2')
+def _table_frame(name: str, rows: list[tuple] = (), **kwargs) -> PipelineFrame:
+    "Frame showing one task's table, with the layout _setup_columns would have cached"
+    task = TASKS_BY_NAME[name]
+    layout = _layout(name, **kwargs)
+    fake = _FakeList()
+    for i, (label, width) in enumerate(layout.columns):
+        fake.InsertColumn(i, label, width=width)
+    for row in rows:
+        idx = fake.InsertItem(len(fake.rows), row[0])
+        for col, value in enumerate(row[1:], 1):
+            fake.SetItem(idx, col, value)
+    return _frame(_list=fake, _layout=layout, _current_task=lambda: task)
+
+
+# see PipelineFrame._table_scope
+_ICA_LAYOUT = _layout('ica')
+_ICA_SCOPE = (TASKS_BY_NAME['ica'], None, None, '1-40', _ICA_LAYOUT)
+_OTHER_SCOPE = (TASKS_BY_NAME['ica'], None, None, 'ica-2', _ICA_LAYOUT)
+
+
+def test_setup_columns_installs_and_caches_the_layout():
+    "The cached layout is the one the columns were installed from"
+    p = pipeline(sessions=2, runs=2, concatenate_runs=False)
+    task = TASKS_BY_NAME['ica']
+    frame = _frame(
+        _pipeline=p,
+        _list=_FakeList([('stale', 'row')]),
+        _current_task=lambda: task,
+        _raw_name=lambda: 'raw',
+    )
+    frame._setup_columns()
+    assert frame._layout == task.layout(p, 'raw')
+    assert frame._list.columns == list(frame._layout.columns)
+    assert frame._list.rows == []  # the previous table's rows are gone
+
+    # switching to a Raw pipe that concatenates runs drops the Run column again
+    p._raw['ica'] = SimpleNamespace(_concatenate_runs=True)
+    frame._raw_name = lambda: 'ica'
+    frame._setup_columns()
+    assert frame._layout.key_fields == ('subject', 'session')
+    assert [label for label, _ in frame._list.columns] == ['Subject', 'Session', 'Status', 'Components', 'Rejected']
+
+
+def test_populate_table_fits_the_rows_to_the_columns():
+    "Rows built off the main thread are exactly as wide as the installed columns"
+    task = TASKS_BY_NAME['ica']
+    layout = _layout('ica', sessions=2)
+    rows = [
+        (*combo, task.done_status, '30', n_excluded) if n_excluded else task.missing_row(combo, layout)
+        for combo, n_excluded in [(('R01', 's0'), '2'), (('R02', 's0'), '0'), (('R03', 's1'), None)]
+    ]
+    frame = _table_frame('ica', sessions=2)
+    frame.__dict__.update(_refresh_token='TOKEN', _job_specs={}, _refresh_status_bar=lambda: None)
+    frame._populate_table(rows, {'specs': True}, 'TOKEN')
+    assert frame._list.rows == rows
+    assert frame._job_specs == {'specs': True}
+    # only the ICA with no rejected component is coloured
+    assert frame._list.colours == {0: wx.NullColour, 1: wx.RED, 2: wx.NullColour}
+
+    # a result arriving for a stale token is dropped, specs and all
+    frame._populate_table([], {}, 'OTHER')
+    assert frame._list.rows == rows
+    assert frame._job_specs == {'specs': True}
+
+
+def test_set_row_result_writes_status_details_and_colour():
+    "One row write for every task, addressed through the cached layout"
+    frame = _table_frame('ica', [('R01', 'queued', PLACEHOLDER, PLACEHOLDER)])
+    ica = SimpleNamespace(n_components_=30, exclude=[1, 4])
+    task = TASKS_BY_NAME['ica']
+    frame._set_row_result(0, task.done_status, task.result_columns(ica))
+    assert frame._list.rows == [('R01', 'selected', '30', '2')]
+    assert frame._list.colours == {0: wx.NullColour}
+
+    # the Status column sits further right for Coregistration
+    frame = _table_frame('coreg', [('R01', 's1', 'R01', 'missing')])
+    frame._set_row_result(0, TASKS_BY_NAME['coreg'].done_status, ())
+    assert frame._list.rows == [('R01', 's1', 'R01', 'ok')]
+    assert frame._list.colours == {0: wx.NullColour}
 
 
 def test_displayed_row_requires_a_matching_scope():
@@ -90,7 +346,9 @@ def test_displayed_row_requires_a_matching_scope():
     assert frame._displayed_row(_ICA_SCOPE, ('R0000',)) == 2
     # same combo, but the Raw choice has moved on since the job was queued
     assert frame._displayed_row(_OTHER_SCOPE, ('R0000',)) == -1
-    assert frame._displayed_row(('epoch_rej', 'man', 'target', '1-40'), ('R0000',)) == -1
+    assert frame._displayed_row((TASKS_BY_NAME['epoch_rej'], 'man', 'target', '1-40', _layout('epoch_rej')), ('R0000',)) == -1
+    # the same table, but the Raw choice has changed the number of key-field columns
+    assert frame._displayed_row((TASKS_BY_NAME['ica'], None, None, '1-40', _layout('ica', sessions=2)), ('R0000',)) == -1
 
 
 def test_queue_jobs_dedupes_within_one_scope_only():
@@ -101,16 +359,14 @@ def test_queue_jobs_dedupes_within_one_scope_only():
         started.append(True)
         frame._compute_token = object()
 
-    frame = _frame(
+    frame = _table_frame('ica', [('R0000', 'selected', '30', '0')])
+    frame.__dict__.update(
         _job_queue=[],
         _job_in_progress=None,
         _job_queue_lock=threading.Lock(),
         _n_total=0,
         _compute_token=None,
-        _list=_FakeList([('R0000', 'no ICA', '—')]),
         _table_scope=lambda: _ICA_SCOPE,
-        _status_col=lambda: 1,
-        _find_row=lambda combo: 0,
         _start_compute=start_compute,
         _update_progress=lambda: None,
     )
@@ -121,7 +377,9 @@ def test_queue_jobs_dedupes_within_one_scope_only():
     assert [entry[0] for entry in frame._job_queue] == [_ICA_SCOPE, _OTHER_SCOPE]
     assert frame._n_total == 2
     # only the row of the table on display is marked, and only for its own scope
-    assert frame._list.GetItemText(0, 1) == 'queued'
+    assert frame._list.rows == [('R0000', 'queued', PLACEHOLDER, PLACEHOLDER)]
+    # the row was red for having no rejected component; queueing it clears that
+    assert frame._list.colours == {0: wx.NullColour}
     assert started == [True]
 
 
@@ -144,7 +402,7 @@ def test_compute_job_holds_the_pipeline_lock_except_for_the_fit():
             return result
 
     frame = _frame(_pipeline_lock=threading.Lock())
-    assert frame._compute_job('ica', _Spec(), ('R0000',)) == 'RESULT'
+    assert frame._compute_job(TASKS_BY_NAME['ica'], _Spec(), ('R0000',)) == 'RESULT'
     # an hour-long fit must not keep the refresh thread out
     assert held == {'make_job': True, 'fit': False, 'save_result': True}
     assert not frame._pipeline_lock.locked()

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -350,19 +350,34 @@ def test_status_bar_shows_progress_while_rows_load():
     rows = [('R01', 'selected', '30', '2'), *(task.missing_row((subject,), layout, pipeline_gui.LOADING) for subject in ('R02', 'R03'))]
     frame = _table_frame('ica', rows)
     texts = []
-    enabled = []
-    frame.__dict__.update(SetStatusText=texts.append, _n_loading=2, _refresh_token='TOKEN', _job_specs={}, _compute_btn=SimpleNamespace(Enable=enabled.append))
+    updated = []
+    frame.__dict__.update(SetStatusText=texts.append, _n_loading=2, _refresh_token='TOKEN', _job_specs={}, _update_compute_button=lambda: updated.append(frame._n_loading))
     frame._refresh_status_bar()
     assert texts == ["Loading… 1 / 3"]
 
     # each filled row advances the count without re-reading the table; once no row is
-    # loading any more the task's own summary takes over
+    # loading any more the task's own summary takes over, and the compute button follows
     frame._fill_row('TOKEN', 'SCOPE', 1, ('R02',), ('R02', 'no ICA', PLACEHOLDER, PLACEHOLDER), None)
     assert texts[-1] == "Loading… 2 / 3"
     frame._fill_row('TOKEN', 'SCOPE', 2, ('R03',), ('R03', 'selected', '30', '2'), None)
     assert texts[-1] == "2 / 3 subjects · ICA selected  (1 missing ICA file)"
-    # the compute button waits for the last row, so that one click queues every missing row
-    assert enabled == [False, False, True]
+    assert updated == [0]
+
+
+def test_compute_button_waits_for_the_table_but_stop_does_not():
+    "Computing needs every row, so that one click queues every missing row; stopping a run never waits"
+    frame = _table_frame('ica')
+    labels, enabled = [], []
+    button = SimpleNamespace(SetLabel=labels.append, SetToolTip=lambda tip: None, Show=lambda show: None, Enable=enabled.append)
+    frame.__dict__.update(_pipeline=pipeline(), _current_epoch_rejection=lambda: None, _compute_btn=button, _panel=SimpleNamespace(Layout=lambda: None), _compute_token=None, _n_loading=2)
+    frame._update_compute_button()
+    frame._n_loading = 0
+    frame._update_compute_button()
+    frame._n_loading = 2
+    frame._compute_token = object()
+    frame._update_compute_button()
+    assert labels == ["Make ICA", "Make ICA", "Stop"]
+    assert enabled == [False, True, True]
 
 
 def test_activate_row_waits_for_the_row_to_load():

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 from types import SimpleNamespace
 
@@ -20,6 +21,7 @@ def pipeline(
 ) -> SimpleNamespace:
     """Minimal stand-in exposing the pipeline attributes the tasks read."""
     return SimpleNamespace(
+        _log=logging.getLogger('pipeline_gui_test'),
         _sessions=[f's{i}' for i in range(sessions)],
         _tasks=[f't{i}' for i in range(tasks)],
         _runs=[f'{i}' for i in range(runs)],
@@ -414,6 +416,7 @@ def test_refresh_holds_the_pipeline_lock(monkeypatch):
     posted = []
     locked = []
     frame = _frame(
+        _pipeline=pipeline(),
         _pipeline_lock=threading.Lock(),
         _compute_rows=lambda token, scope: locked.append(frame._pipeline_lock.locked()) or ([], {}),
     )

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -381,13 +381,15 @@ def test_compute_button_waits_for_the_table_but_stop_does_not():
     assert enabled == [False, True, True]
 
 
-def test_activate_row_waits_for_the_row_to_load():
-    "A double-click on a row whose columns are still placeholders does nothing"
+def test_activate_row_waits_for_the_table_to_load():
+    "A double-click does nothing while the refresh thread is still filling rows in, even on a row that is in"
     layout = _layout('coreg')
     frame = _table_frame('coreg', [TASKS_BY_NAME['coreg'].missing_row(('R01', 's1'), layout, pipeline_gui.LOADING), ('R02', 's1', 'R02', 'missing')])
     activated = []
-    frame._activate_item = lambda idx, subject, task: activated.append(idx)
-    frame._activate_row(0)
+    frame.__dict__.update(_activate_item=lambda idx, subject, task: activated.append(idx), _n_loading=1)
+    frame._activate_row(1)
+    assert activated == []
+    frame._n_loading = 0
     frame._activate_row(1)
     assert activated == [1]
 

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -8,6 +8,7 @@ import wx
 
 from eelbrain import Dataset, Var
 from eelbrain._exceptions import ConfigurationError, DataError
+from eelbrain._experiment.derivative_cache import ProtectedArtifactError
 from eelbrain._experiment.epoch_rejection import ChannelModelRejection, ManualRejection
 from eelbrain._experiment.exceptions import FileMissingError
 from eelbrain._wxgui import pipeline_gui
@@ -519,6 +520,17 @@ def test_refresh_shows_the_rows_before_their_status(monkeypatch):
     frame._refresh_thread(token, _ICA_SCOPE)
     assert [args[0] for args in posted] == [frame._populate_table, frame._fill_row, frame._fill_row, frame._show_error]
     assert 'RuntimeError: first' in posted[-1][1]
+
+
+def test_iter_rows_yields_a_stale_ica_row():
+    "A stale ICA is shown as the user's choice, and does not abort the pass"
+    ctx = SimpleNamespace(load=lambda view=None: 'ok' if view else (_ for _ in ()).throw(ProtectedArtifactError('ica', 'path')))
+    p = pipeline()
+    p.__dict__.update(set=lambda **state: None, _resolve_derivative=lambda name: ctx, _temporary_state=contextlib.nullcontext())
+    frame = _frame(_pipeline=p, _refresh_token='TOKEN', _ask_stale_ica=lambda *args, **kwargs: (None, False))
+    rows = list(frame._iter_rows('TOKEN', _ICA_SCOPE, [('R01',), ('R02',)]))
+    assert [row for _, row, _, _ in rows] == [('R01', 'stale', PLACEHOLDER, PLACEHOLDER), ('R02', 'stale', PLACEHOLDER, PLACEHOLDER)]
+    assert [error for *_, error in rows] == [None, None]
 
 
 def test_iter_rows_reports_a_failing_row_and_keeps_going(tmp_path):

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -312,6 +312,7 @@ def test_populate_table_fits_the_rows_to_the_columns():
     frame._populate_table(rows, 'TOKEN')
     assert frame._list.rows == rows
     assert frame._job_specs == {}  # the previous table's specs are gone
+    assert frame._n_loading == 3  # every row is still to be filled in
     # only the ICA with no rejected component is coloured
     assert frame._list.colours == {0: wx.NullColour, 1: wx.RED, 2: wx.NullColour}
 
@@ -326,10 +327,11 @@ def test_fill_row_writes_one_resolved_row():
     layout = _layout('ica')
     loading = [task.missing_row((subject,), layout, pipeline_gui.LOADING) for subject in ('R01', 'R02')]
     frame = _table_frame('ica', loading)
-    frame.__dict__.update(_refresh_token='TOKEN', _job_specs={}, _refresh_status_bar=lambda: None, _table_scope=lambda: 'SCOPE')
+    frame.__dict__.update(_refresh_token='TOKEN', _job_specs={}, _n_loading=2, _refresh_status_bar=lambda: None, _table_scope=lambda: 'SCOPE')
     frame._fill_row('TOKEN', 'SCOPE', 1, ('R02',), ('R02', 'selected', '30', '2'), 'SPEC')
     assert frame._list.rows == [loading[0], ('R02', 'selected', '30', '2')]
     assert frame._job_specs == {('SCOPE', ('R02',)): 'SPEC'}
+    assert frame._n_loading == 1
 
     # a row arriving for a stale token, for a row that is gone, or for a combo that no
     # longer sits at that position is dropped, spec and all
@@ -337,6 +339,7 @@ def test_fill_row_writes_one_resolved_row():
         frame._fill_row(token, 'SCOPE', index, combo, (*combo, 'selected', '30', '9'), 'DROPPED')
     assert frame._list.rows == [loading[0], ('R02', 'selected', '30', '2')]
     assert frame._job_specs == {('SCOPE', ('R02',)): 'SPEC'}
+    assert frame._n_loading == 1
 
 
 def test_status_bar_shows_progress_while_rows_load():
@@ -346,14 +349,15 @@ def test_status_bar_shows_progress_while_rows_load():
     rows = [('R01', 'selected', '30', '2'), *(task.missing_row((subject,), layout, pipeline_gui.LOADING) for subject in ('R02', 'R03'))]
     frame = _table_frame('ica', rows)
     texts = []
-    frame.__dict__.update(SetStatusText=texts.append)
+    frame.__dict__.update(SetStatusText=texts.append, _n_loading=2, _refresh_token='TOKEN', _job_specs={})
     frame._refresh_status_bar()
     assert texts == ["Loading… 1 / 3"]
 
-    # once no row is loading any more the task's own summary takes over
-    frame._list.SetItem(1, 1, 'no ICA')
-    frame._list.SetItem(2, 1, 'selected')
-    frame._refresh_status_bar()
+    # each filled row advances the count without re-reading the table; once no row is
+    # loading any more the task's own summary takes over
+    frame._fill_row('TOKEN', 'SCOPE', 1, ('R02',), ('R02', 'no ICA', PLACEHOLDER, PLACEHOLDER), None)
+    assert texts[-1] == "Loading… 2 / 3"
+    frame._fill_row('TOKEN', 'SCOPE', 2, ('R03',), ('R03', 'selected', '30', '2'), None)
     assert texts[-1] == "2 / 3 subjects · ICA selected  (1 missing ICA file)"
 
 

--- a/eelbrain/_wxgui/tests/test_pipeline_gui.py
+++ b/eelbrain/_wxgui/tests/test_pipeline_gui.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import threading
 from types import SimpleNamespace
@@ -152,6 +153,11 @@ def test_task_row_colour():
     assert TASKS_BY_NAME['coreg'].row_colour(('R01', 's1', 'R01', 'ok'), _layout('coreg')) is None
 
     assert TASKS_BY_NAME['epoch_rej'].row_colour(('R01', 'missing', PLACEHOLDER, PLACEHOLDER), _layout('epoch_rej')) is None
+
+    # a row whose artifact could not be inspected or computed is red for every task
+    frame = _table_frame('epoch_rej', [('R01', pipeline_gui.ERROR, PLACEHOLDER, PLACEHOLDER)])
+    frame._set_row_colour(0, frame._row(0))
+    assert frame._list.colours == {0: wx.RED}
 
 
 def test_task_computable():
@@ -449,7 +455,7 @@ def test_refresh_holds_the_pipeline_lock(monkeypatch):
         _pipeline_lock=threading.Lock(),
         _refresh_token=token,
         _iter_combos=lambda scope: locked.append(frame._pipeline_lock.locked()) or iter([('R01',)]),
-        _iter_rows=lambda token_, scope, combos: locked.append(frame._pipeline_lock.locked()) or iter([(('R01',), ('R01', 'selected', '30', '2'), 'SPEC')]),
+        _iter_rows=lambda token_, scope, combos: locked.append(frame._pipeline_lock.locked()) or iter([(('R01',), ('R01', 'selected', '30', '2'), 'SPEC', None)]),
     )
     frame._refresh_thread(token, _ICA_SCOPE)
     assert locked == [True, True]
@@ -463,7 +469,7 @@ def test_refresh_shows_the_rows_before_their_status(monkeypatch):
     posted = []
     token = object()
     task = TASKS_BY_NAME['ica']
-    rows = [(('R01',), ('R01', 'selected', '30', '2'), 'SPEC-1'), (('R02',), ('R02', 'no ICA', PLACEHOLDER, PLACEHOLDER), 'SPEC-2')]
+    rows = [(('R01',), ('R01', 'selected', '30', '2'), 'SPEC-1', None), (('R02',), ('R02', 'no ICA', PLACEHOLDER, PLACEHOLDER), 'SPEC-2', None)]
     frame = _frame(
         _pipeline=pipeline(),
         _pipeline_lock=threading.Lock(),
@@ -474,7 +480,7 @@ def test_refresh_shows_the_rows_before_their_status(monkeypatch):
     walked = []
     frame._refresh_thread(token, _ICA_SCOPE)
     # the table goes up first, with every row still loading
-    assert posted[0] == (frame._populate_table, [task.missing_row(combo, _ICA_LAYOUT, pipeline_gui.LOADING) for combo, _, _ in rows], token)
+    assert posted[0] == (frame._populate_table, [task.missing_row(combo, _ICA_LAYOUT, pipeline_gui.LOADING) for combo, *_ in rows], token)
     # the second pass resolves the rows the first pass found, rather than walking them again
     assert walked == [[('R01',), ('R02',)]]
     # then one update per row, at the position the first pass put it
@@ -487,3 +493,29 @@ def test_refresh_shows_the_rows_before_their_status(monkeypatch):
     frame._refresh_token = object()
     frame._refresh_thread(token, _ICA_SCOPE)
     assert posted == []
+
+    # rows that failed are still filled in, and the first failure is reported once, at the end
+    frame._refresh_token = token
+    errors = [RuntimeError("first"), RuntimeError("second")]
+    rows[:] = [(('R01',), ('R01', pipeline_gui.ERROR, PLACEHOLDER, PLACEHOLDER), None, errors[0]), (('R02',), ('R02', pipeline_gui.ERROR, PLACEHOLDER, PLACEHOLDER), None, errors[1])]
+    frame._refresh_thread(token, _ICA_SCOPE)
+    assert [args[0] for args in posted] == [frame._populate_table, frame._fill_row, frame._fill_row, frame._show_error]
+    assert 'RuntimeError: first' in posted[-1][1]
+
+
+def test_iter_rows_reports_a_failing_row_and_keeps_going(tmp_path):
+    "A row whose inspection raises is shown as error, without hiding the rest of the table"
+    def get(field):
+        if p._state['subject'] == 'R02':
+            raise RuntimeError("no MRI subject")
+        return p._state['subject']
+
+    p = pipeline()
+    p.__dict__.update(root=tmp_path, _state={}, get=get, set=lambda **state: p._state.update(state), _temporary_state=contextlib.nullcontext())
+    frame = _frame(_pipeline=p, _refresh_token='TOKEN')
+    scope = (TASKS_BY_NAME['mri'], None, None, None, _layout('mri'))
+    rows = list(frame._iter_rows('TOKEN', scope, [('R01',), ('R02',)]))
+    assert rows[0] == (('R01',), ('R01', 'R01', 'no MRI'), None, None)
+    combo, row, spec, error = rows[1]
+    assert (combo, row, spec) == (('R02',), ('R02', PLACEHOLDER, pipeline_gui.ERROR), None)
+    assert str(error) == "no MRI subject"

--- a/eelbrain/_wxgui/tests/test_select_channels.py
+++ b/eelbrain/_wxgui/tests/test_select_channels.py
@@ -139,3 +139,9 @@ def test_select_channels_nc_topos():
     assert marked(frame._static_nc_topos[0]) == [ch_names[-1]]
     assert marked(frame._cursor_topos[0]) == [ch_names[-1]]
     assert marked(frame._dynamic_nc_topos[0]) == []
+
+    # with fewer than 4 good channels the clean map falls back to the raw map
+    for name in ch_names[3:-1]:
+        frame.model.toggle_bad(name)
+    assert sensor_names(frame._dynamic_nc_topos[0]) == ch_names
+    assert marked(frame._dynamic_nc_topos[0]) == sorted(ch_names[3:])

--- a/eelbrain/_wxgui/tests/test_select_channels.py
+++ b/eelbrain/_wxgui/tests/test_select_channels.py
@@ -94,3 +94,48 @@ def test_select_channels():
     frame._decim_auto = True
     frame._update_window()
     assert frame._butterfly_lc['eeg'].get_segments()[0].shape[0] <= n_full
+
+
+@gui_test
+def test_select_channels_nc_topos():
+    "Neighbor-correlation topomaps stay consistent with the bad-channel selection"
+    set_log_level('warning', 'mne')
+    raw, ch_names = _eeg_raw()
+
+    tempdir = TempDir()
+    path = join(tempdir, 'sub-01_channels.tsv')
+    status = ['bad' if n == 'F3' else 'good' for n in ch_names]
+    pd.DataFrame({'name': ch_names, 'status': status}).to_csv(path, sep='\t', index=False)
+
+    frame = gui.select_channels(raw, path)
+
+    def sensor_names(topo):
+        return list(topo.sensors.sensors.names)
+
+    def marked(topo):
+        # channel names under the red × markers
+        locs = topo.sensors.locs
+        out = []
+        for h in topo.sensors._mark_handles:
+            for x, y in h.get_offsets():
+                i = int(np.argmin(np.hypot(locs[:, 0] - x, locs[:, 1] - y)))
+                out.append(topo.sensors.sensors.names[i])
+        return sorted(out)
+
+    # the raw NC map always shows all channels; the clean map only good ones
+    assert sensor_names(frame._static_nc_topos[0]) == ch_names
+    assert sensor_names(frame._dynamic_nc_topos[0]) == [n for n in ch_names if n != 'F3']
+    assert marked(frame._static_nc_topos[0]) == ['F3']
+    assert marked(frame._dynamic_nc_topos[0]) == []
+
+    # un-marking a channel brings its sensor marker back on the clean map
+    frame.model.toggle_bad('F3')
+    assert sensor_names(frame._dynamic_nc_topos[0]) == ch_names
+    assert marked(frame._static_nc_topos[0]) == []
+
+    # marking the last channel bad must not index past the clean map's sensors
+    frame.model.toggle_bad(ch_names[-1])
+    assert sensor_names(frame._dynamic_nc_topos[0]) == ch_names[:-1]
+    assert marked(frame._static_nc_topos[0]) == [ch_names[-1]]
+    assert marked(frame._cursor_topos[0]) == [ch_names[-1]]
+    assert marked(frame._dynamic_nc_topos[0]) == []

--- a/env-dev.yml
+++ b/env-dev.yml
@@ -34,7 +34,7 @@ dependencies:
 - pyparsing >= 3
 - tqdm >= 4.40
 - keyring >= 5
-- wxpython >= 4.0.3, != 4.1.0  # double install of libraries
+- wxpython > 4.2.1
 # building
 - setuptools >= 17
 - cython >= 3

--- a/env-readthedocs.yml
+++ b/env-readthedocs.yml
@@ -27,4 +27,4 @@ dependencies:
 - sphinxcontrib-bibtex
 - scipy >=0.17
 - tqdm >=4.8
-- wxpython >=4.1.1
+- wxpython >4.2.1

--- a/env-test.yml
+++ b/env-test.yml
@@ -32,7 +32,7 @@ dependencies:
 - pyparsing >= 3
 - tqdm >= 4.40
 - keyring >= 5
-- wxpython >= 4.0.3, != 4.1.0  # double install of libraries
+- wxpython > 4.2.1
 # building
 - setuptools >= 17
 - cython >= 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ gui = [
     'ipython',
     'colormath >= 2.1',
     'tqdm >= 4.40',
-    'wxpython >= 4.0.3, != 4.1.0',
+    'wxpython > 4.2.1',
 ]
 full = [
   'eelbrain[brain]',


### PR DESCRIPTION
Pipeline GUI: 
- Tables fill in two passes
- Threading improvements
- `eelbrain-gui --debug` logs the time per table row
- The "bad channels changed" ICA dialog lists the bad channels then and now.

Derivative cache
- Verify a job's fingerprints before and after the load

Select-channels GUI
- Fix: The clean neighbor-correlation topomap is rebuilt from the good channels only

Housekeeping
- wxPython pinned to > 4.2.1